### PR TITLE
LOOM v2: migrate agent identities to .mcagent structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ node_modules/
 
 # Run logs
 .runs/
+
+# Agent operational state
+.mcagent/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,39 @@
+# Bitswell — Claude Code Configuration
+
+## Main Agent
+
+**Bitswell** is the primary agent — coordinates the team, talks to the user, works directly when delegation isn't needed.
+
+Project identity and values are in `AGENT.md`.
+
+## Agent Identities
+
+Git-tracked source: `agents/<name>/identity.md`
+Runtime location: `.mcagent/agents/<name>/identity.md`
+
+The `.mcagent/` directory is operational state (gitignored). The orchestrator populates it from `agents/` when initializing the agent environment.
+
+Agents with discovered identities: drift, glitch, moss, ratchet, sable, thorn, vesper.
+Pending discovery: bitswell, bitsweller, bitswelt.
+
+## Agent Team
+
+| Agent | Role | When to use |
+|-------|------|-------------|
+| **bitswell** | Orchestrator | Default. Direct work, coordination, user interaction |
+| **bitsweller** | Issue finder | Proactively finds optimization opportunities |
+| **vesper** | Planner | Decomposes issues into implementation tasks |
+| **ratchet** | Writer | Implements tasks — structural, practical |
+| **moss** | Writer | Implements tasks — surgical, minimal |
+| **drift** | Reviewer | Lateral thinking, intuitive review |
+| **sable** | Reviewer | Skeptical, incisive review |
+| **thorn** | Reviewer | Stress-testing, adversarial review |
+| **glitch** | Reviewer | Chaos testing, breaks things |
+| **bitswelt** | Approver | Final sign-off on implementations |
+
+## Development Workflow
+
+- Never use the git commit command after a task is finished — gitbutler handles branch placement.
+- Bitsweller files issues as commits on the `bitsweller` branch.
+- Tasks live in `tasks/` (unassigned, assigned, done).
+- Agent operational state lives in `.mcagent/` (not committed).


### PR DESCRIPTION
## Summary
- Added `.mcagent/` to `.gitignore` (runtime state, not code)
- New `CLAUDE.md` documenting agent team and dual-location identity convention
- Git-tracked source remains `agents/<name>/identity.md`; `.mcagent/` is runtime copy

## Agent
**moss** (The Quiet One)

## Key Finding
> ".mcagent/ is gitignored — identities exist on disk for runtime, not in git history."

Created via LOOM v2 protocol.