### PR TITLE
LOOM v2: consolidated spec with all bootstrap fixes

### DIFF
--- a/.claude/skills/loom/loom-dispatch.sh
+++ b/.claude/skills/loom/loom-dispatch.sh
@@ -83,6 +83,14 @@ find_identity() {
   echo ""; return 1
 }
 
+# --- dependency helpers ---
+
+# Convert dependency format "agent/slug" to branch name "loom/agent-slug".
+dep_to_branch() {
+  local dep="$1"
+  echo "loom/${dep//\//-}"
+}
+
 # --- dependency checking ---
 
 check_dependencies() {
@@ -91,15 +99,38 @@ check_dependencies() {
   local IFS=','
   for dep in $deps; do
     dep="$(echo "$dep" | xargs)"
-    local dep_agent="${dep%%/*}" completed=false
-    for branch in $(git branch --list "loom/${dep_agent}*" --format='%(refname:short)' 2>/dev/null); do
+    local branch_name
+    branch_name="$(dep_to_branch "$dep")"
+    # Check the exact branch for a COMPLETED status
+    if git rev-parse --verify "$branch_name" >/dev/null 2>&1; then
       local s
-      s="$(git log -1 --format='%(trailers:key=Task-Status,valueonly)' --grep='Task-Status:' "$branch" 2>/dev/null | head -1 | xargs)"
-      [[ "$s" == "COMPLETED" ]] && { completed=true; break; }
-    done
-    [[ "$completed" != "true" ]] && { echo "Dep not met: $dep" >&2; return 1; }
+      s="$(git log -1 --format='%(trailers:key=Task-Status,valueonly)' --grep='Task-Status:' "$branch_name" 2>/dev/null | head -1 | xargs)"
+      [[ "$s" == "COMPLETED" ]] && continue
+    fi
+    echo "Dep not met: $dep (branch: $branch_name)" >&2
+    return 1
   done
   return 0
+}
+
+# --- idempotency ---
+
+lock_file_path() {
+  echo "$MCAGENT_DIR/agents/$1/$2/.dispatch-lock"
+}
+
+is_dispatched() {
+  local lock
+  lock="$(lock_file_path "$1" "$2")"
+  [[ -f "$lock" ]]
+}
+
+write_lock() {
+  local lock pid="$2"
+  lock="$(lock_file_path "$3" "$4")"
+  mkdir -p "$(dirname "$lock")"
+  echo "pid=$pid" > "$lock"
+  echo "dispatched=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$lock"
 }
 
 # --- dispatch ---
@@ -116,6 +147,12 @@ dispatch_agent() {
   echo "  Scope:        $SCOPE"
   echo "  Dependencies: $DEPENDENCIES"
   echo "  Budget:       $BUDGET"
+
+  # Idempotency: skip if already dispatched
+  if is_dispatched "$AGENT_ID" "$ASSIGNMENT_ID"; then
+    echo "  SKIP: already dispatched (lock exists at $(lock_file_path "$AGENT_ID" "$ASSIGNMENT_ID"))"
+    return 0
+  fi
 
   local agent_json worktree identity
   agent_json="$(find_agent_json "$AGENT_ID" "$ASSIGNMENT_ID")" || true
@@ -138,30 +175,62 @@ dispatch_agent() {
   local task_body
   task_body="$(git log -1 --format='%b' "$sha")"
 
-  # Write prompt to temp file for the spawn command
+  # Write prompt to temp file for the spawn command.
+  # Use quoted heredoc to prevent shell expansion of task_body.
   local prompt_file
   prompt_file="$(mktemp)"
-  cat > "$prompt_file" <<PROMPT
-You are agent "$AGENT_ID". Your assignment is "$ASSIGNMENT_ID".
+  trap 'rm -f "$prompt_file"' EXIT
+
+  cat > "$prompt_file" <<'PROMPT'
+You are agent "__AGENT_ID__". Your assignment is "__ASSIGNMENT_ID__".
 Your working directory is this git checkout. Use git commands normally (no -C flags needed).
-Read your identity: $identity
-Read your AGENT.json: $agent_json
+Read your identity: __IDENTITY__
+Read your AGENT.json: __AGENT_JSON__
 Your task (from the assignment commit):
-$task_body
+__TASK_BODY__
 Commit protocol:
-- Every commit: Agent-Id: $AGENT_ID, Session-Id: $agent_session_id
+- Every commit: Agent-Id: __AGENT_ID__, Session-Id: __SESSION_ID__
 - First commit: Task-Status: IMPLEMENTING
 - Final commit: Task-Status: COMPLETED with Key-Finding trailer(s)
 Build it. No ceremony.
 PROMPT
 
+  # Inject controlled variables into the template via sed.
+  # task_body uses a temp file approach to handle multiline + special chars safely.
+  sed -i "s|__AGENT_ID__|${AGENT_ID}|g" "$prompt_file"
+  sed -i "s|__ASSIGNMENT_ID__|${ASSIGNMENT_ID}|g" "$prompt_file"
+  sed -i "s|__IDENTITY__|${identity}|g" "$prompt_file"
+  sed -i "s|__AGENT_JSON__|${agent_json}|g" "$prompt_file"
+  sed -i "s|__SESSION_ID__|${agent_session_id}|g" "$prompt_file"
+
+  # Replace __TASK_BODY__ with the actual task body.
+  # Use a temp file + awk to handle multiline content and special characters.
+  local body_file
+  body_file="$(mktemp)"
+  printf '%s' "$task_body" > "$body_file"
+  awk -v placeholder="__TASK_BODY__" -v bodyfile="$body_file" '
+    $0 ~ placeholder {
+      while ((getline line < bodyfile) > 0) print line
+      close(bodyfile)
+      next
+    }
+    { print }
+  ' "$prompt_file" > "${prompt_file}.tmp"
+  mv "${prompt_file}.tmp" "$prompt_file"
+  rm -f "$body_file"
+
   echo "  Prompt: $prompt_file"
   echo "  Spawning via: $SPAWN_CMD"
   echo "  PWD: $worktree"
 
-  # cd into the worktree before spawning — agent sees it as PWD
+  # cd into the worktree before spawning -- agent sees it as PWD
   (cd "$worktree" && "$SPAWN_CMD" "$prompt_file") &
-  echo "  PID: $!"
+  local spawn_pid=$!
+  echo "  PID: $spawn_pid"
+
+  # Write lock file with PID to prevent double-dispatch
+  write_lock "$prompt_file" "$spawn_pid" "$AGENT_ID" "$ASSIGNMENT_ID"
+
   echo "  Agent $AGENT_ID dispatched."
 }
 

--- a/.claude/skills/loom/loom-spawn.sh
+++ b/.claude/skills/loom/loom-spawn.sh
@@ -20,6 +20,9 @@ EXTRA_ARGS="${CLAUDE_ARGS:-}"
 
 [[ -f "$PROMPT_FILE" ]] || { echo "Error: prompt file not found: $PROMPT_FILE" >&2; exit 1; }
 
+# Clean up prompt file on exit
+trap 'rm -f "$PROMPT_FILE"' EXIT
+
 # Verify we're in a git worktree
 git rev-parse --is-inside-work-tree >/dev/null 2>&1 || {
   echo "Error: not inside a git worktree. loom-dispatch.sh should cd into the worktree before calling this." >&2
@@ -30,7 +33,16 @@ echo "loom-spawn: worktree=$(pwd)"
 echo "loom-spawn: prompt=$PROMPT_FILE ($(wc -c < "$PROMPT_FILE") bytes)"
 echo "loom-spawn: invoking $CLAUDE"
 
-# Spawn Claude Code with the prompt
-# --print: non-interactive, output result to stdout
-# --dangerously-skip-permissions: agent needs full access to its worktree
-exec "$CLAUDE" --print $EXTRA_ARGS < "$PROMPT_FILE"
+# Build args array. Agent needs tools (interactive mode, no --print).
+# Add --yes for auto-approval unless CLAUDE_ARGS already contains it.
+ARGS=()
+if [[ -n "$EXTRA_ARGS" ]]; then
+  # shellcheck disable=SC2206
+  ARGS=($EXTRA_ARGS)
+fi
+if [[ "$EXTRA_ARGS" != *"--yes"* ]]; then
+  ARGS+=(--yes)
+fi
+
+# Spawn Claude Code with the prompt. Agent runs in interactive mode with tools.
+exec "$CLAUDE" "${ARGS[@]}" < "$PROMPT_FILE"

--- a/.claude/skills/loom/references/mcagent-spec.md
+++ b/.claude/skills/loom/references/mcagent-spec.md
@@ -1,19 +1,12 @@
 # `.mcagent/` Directory Specification
 
-**Version**: 0.2.0 | **Status**: Draft | **Companion to**: LOOM Protocol v2
+**Version**: 1.0.0-draft | **Protocol**: `loom/1` | **Status**: Draft
 
 ---
 
 ## 1. Purpose
 
 Separate agent state from the codebase. The `.mcagent/` directory is the operational root for all agent activity. It contains identity, assignment metadata, and worktrees — but never protocol files inside deliverable code.
-
-This specification addresses five failures identified in LOOM v1 (see RETRO.md):
-1. Protocol files polluting code worktrees
-2. Anonymous, stateless agents
-3. Single-repo assumption
-4. Synchronous orchestrator bottleneck
-5. Ceremony overhead for simple tasks
 
 ---
 
@@ -47,7 +40,7 @@ The layers are strictly nested. Identity outlives any assignment. An assignment 
 
 A lowercase alphanumeric string. No spaces, no underscores. Examples: `ratchet`, `moss`, `drift`, `vesper`.
 
-Agent names are stable across the lifetime of the `.mcagent/` installation. They are proper nouns -- they refer to a specific agent with a specific identity.
+Agent names are stable across the lifetime of the `.mcagent/` installation. They are proper nouns — they refer to a specific agent with a specific identity.
 
 ### 3.2 Identity File
 
@@ -66,14 +59,14 @@ The sequence provides ordering. The slug provides human readability. Together th
 
 ### 3.4 AGENT.json
 
-Lives inside the assignment directory, **outside** the worktree. This is the critical distinction from LOOM v1, where AGENT.json was committed to the agent's branch alongside deliverable code.
+Lives inside the assignment directory, **outside** the worktree. This is the critical distinction — AGENT.json is never committed to the agent's code branch.
 
 ```json
 {
   "agent_id": "<agent-name>",
   "assignment_id": "<sequence>-<slug>",
   "session_id": "<uuid>",
-  "protocol_version": "loom/2",
+  "protocol_version": "loom/1",
   "repo": "<org>/<repo>",
   "base_ref": "<branch-or-sha>",
   "context_window_tokens": 1000000,
@@ -91,13 +84,24 @@ Lives inside the assignment directory, **outside** the worktree. This is the cri
 }
 ```
 
-Fields carried forward from LOOM v1: `agent_id`, `session_id`, `protocol_version`, `context_window_tokens`, `token_budget`, `dependencies`, `scope`, `timeout_seconds`.
+**Field constraints:**
 
-New fields:
-- `assignment_id`: Matches the directory name. Allows the agent to identify its own assignment.
-- `repo`: The target repository in `<org>/<repo>` format.
-- `base_ref`: The branch or commit the worktree was created from.
-- `dispatch`: How this agent was triggered. `sync` means the orchestrator spawned it directly. `push-event` means a commit on `trigger_ref` initiated dispatch.
+| Field | Type | Required | Constraints |
+|-------|------|----------|-------------|
+| `agent_id` | string | yes | Kebab-case (`[a-z0-9]+(-[a-z0-9]+)*`), unique within the repository |
+| `assignment_id` | string | yes | Matches the assignment directory name |
+| `session_id` | string | yes | UUID v4, unique per agent invocation |
+| `protocol_version` | string | yes | Literal `"loom/1"` |
+| `repo` | string | yes | Target repository in `<org>/<repo>` format |
+| `base_ref` | string | yes | Branch name or commit SHA the worktree was created from |
+| `context_window_tokens` | integer | yes | Positive integer |
+| `token_budget` | integer | yes | Positive integer, <= `context_window_tokens` |
+| `dependencies` | string[] | yes | Array of `<agent>/<slug>` refs (may be empty `[]`). Graph MUST be a DAG. |
+| `scope.paths_allowed` | string[] | yes | Non-empty array of globs relative to worktree root |
+| `scope.paths_denied` | string[] | yes | Array of globs (may be empty `[]`). Deny takes precedence over allow. |
+| `timeout_seconds` | integer | yes | Positive integer. Default: 3600 |
+| `dispatch.mode` | string | yes | `"sync"` or `"push-event"` |
+| `dispatch.trigger_ref` | string | conditional | Required when `dispatch.mode` is `"push-event"` |
 
 ### 3.5 Worktree
 
@@ -112,16 +116,16 @@ The worktree path is always `.mcagent/agents/<name>/<assignment>/worktree/`. Imp
 ### 3.6 Orchestrator Identity
 
 The orchestrator (`bitswell`) MUST have its own agent directory at `.mcagent/agents/bitswell/` with:
-- `identity.md` -- persistent orchestrator identity
-- `orchestrator.json` -- declares orchestrator role and `.mcagent/**` write scope
+- `identity.md` — persistent orchestrator identity
+- `orchestrator.json` — declares orchestrator role and `.mcagent/**` write scope
 
-All orchestrator commits use `Agent-Id: bitswell`. There is no separate "orchestrator" identity.
+All orchestrator commits use `Agent-Id: bitswell`. There is no separate "orchestrator" identity — the orchestrator is an agent with elevated privileges.
 
 ```json
 {
   "agent_id": "bitswell",
   "role": "orchestrator",
-  "protocol_version": "loom/2",
+  "protocol_version": "loom/1",
   "scope": {
     "paths_allowed": [".mcagent/**"],
     "paths_denied": []
@@ -139,25 +143,81 @@ All orchestrator commits use `Agent-Id: bitswell`. There is no separate "orchest
 
 Only the orchestrator writes to `.mcagent/`. Agents write only within their worktree (their PWD).
 
+### 3.7 Branch Naming
+
+**Pattern:** `loom/<agent>-<slug>`
+
+The branch name encodes the agent and assignment. The `<agent>` segment is the agent name from Section 3.1. The `<slug>` segment is the slug from the assignment directory name (Section 3.3), without the sequence number.
+
+**Examples:**
+- Agent `ratchet`, assignment `2-commit-schema` → branch `loom/ratchet-commit-schema`
+- Agent `moss`, assignment `4-migrate-identities` → branch `loom/moss-migrate-identities`
+
+**Dependency encoding:** Dependencies in AGENT.json use the format `<agent>/<slug>`. To resolve a dependency to a branch name, convert `<agent>/<slug>` to `loom/<agent>-<slug>`. For example, dependency `ratchet/commit-schema` maps to branch `loom/ratchet-commit-schema`.
+
+**Constraints:**
+- Kebab-case throughout: matches `[a-z0-9]+(-[a-z0-9]+)*`
+- Maximum length: 63 characters (git ref component limit)
+- Each agent works exclusively on its own branch
+- The orchestrator creates the branch at worktree creation time, branching from `base_ref`
+- Agents MUST NOT push to or modify any other branch
+
 ---
 
 ## 4. Protocol State in Commits
 
-LOOM v1 encoded protocol state in files (STATUS.md, PLAN.md, MEMORY.md). This spec moves protocol state to commit messages and trailers.
+Protocol state lives in commit messages and trailers. The worktree diff contains only deliverable changes.
 
-The commit-message protocol schema is defined in a companion specification. This document defines only the directory structure.
+Key principle: `git log --format` extracts all protocol state.
 
-Key principle: `git log --format` extracts all protocol state. The worktree diff contains only deliverable changes.
-
-Required commit trailers (carried forward from LOOM v1, extended):
+Required commit trailers:
 - `Agent-Id`: Agent name
 - `Session-Id`: UUID for this invocation
-- `Task-Status`: Current lifecycle state (ASSIGNED, IMPLEMENTING, COMPLETED, BLOCKED, FAILED). Note: PLANNING existed in LOOM v1 for the two-phase spawn. In v2, single-phase spawn is the default, so PLANNING is removed from the state machine.
+- `Task-Status`: Current lifecycle state (ASSIGNED, IMPLEMENTING, COMPLETED, BLOCKED, FAILED)
 
 Optional trailers for richer state:
 - `Files-Changed`: Integer count
-- `Key-Finding`: One-line discovery worth preserving
+- `Key-Finding`: One-line discovery worth preserving (repeatable)
+- `Decision`: Non-obvious choice with rationale, format `<what> -- <why>` (repeatable)
+- `Deviation`: Departure from task spec, format `<what> -- <why>` (repeatable)
 - `Blocked-Reason`: Present when Task-Status is BLOCKED
+- `Error-Category`: Present when Task-Status is FAILED
+- `Error-Retryable`: Present when Task-Status is FAILED
+- `Heartbeat`: ISO-8601 UTC timestamp (see Section 4.2)
+
+See `schemas.md` for the full trailer vocabulary, required trailers per state, and commit templates.
+
+### 4.1 Orchestrator Post-Terminal Commits
+
+After an agent reaches a terminal state (COMPLETED or FAILED), the orchestrator MAY commit to the agent's branch for hotfixes, rebasing, or integration preparation. These commits:
+
+- MUST use type `chore(loom):` in the commit subject
+- MUST include `Agent-Id: bitswell` and `Session-Id` trailers
+- MUST NOT carry a `Task-Status` trailer
+
+Orchestrator post-terminal commits are explicitly outside the state machine. They do not change the agent's status. The agent's terminal status is determined by the last commit that carries a `Task-Status` trailer.
+
+### 4.2 Heartbeat
+
+Agents MUST commit a `Heartbeat` trailer at least every 5 minutes while running. The trailer value is an ISO-8601 UTC timestamp.
+
+```
+chore(loom): checkpoint
+
+Agent-Id: ratchet
+Session-Id: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+Heartbeat: 2026-04-03T14:30:00Z
+```
+
+Work commits MAY include the `Heartbeat` trailer alongside other trailers. Dedicated heartbeat commits (with no file changes) are permitted when the agent has no deliverable changes to commit.
+
+The orchestrator monitors agent branches for stale heartbeats. If `now - latest_heartbeat > timeout_seconds` from AGENT.json, the agent is considered stale. Stale agents are terminated: SIGTERM, wait 10 seconds, then SIGKILL.
+
+**Query to check liveness:**
+
+```bash
+git log -1 --format='%(trailers:key=Heartbeat,valueonly)' <branch>
+```
 
 ---
 
@@ -165,7 +225,7 @@ Optional trailers for richer state:
 
 ### 5.1 Single-Repo (Default)
 
-The `.mcagent/` directory lives inside the coordination repo (e.g., `bitswell/bitswell`). This repo is the single source of truth for agent state. Most assignments create worktrees from this same repo.
+The `.mcagent/` directory lives inside the coordination repo (e.g., `bitswell/bitswell`). This repo is the single source of truth for agent state. Most assignments create worktrees from this same repo. The `.mcagent/` directory SHOULD be added to `.gitignore` — it is local operational state, not deliverable code.
 
 ### 5.2 External Repos via `.repos/`
 
@@ -206,7 +266,8 @@ The orchestrator:
 1. Creates the assignment directory: `.mcagent/agents/<name>/<sequence>-<slug>/`
 2. Writes AGENT.json into the assignment directory.
 3. Creates a git worktree at `<assignment>/worktree/` from the target repo's `base_ref`.
-4. Spawns the agent (sync) or commits a dispatch trigger (push-event).
+4. Commits the `Task-Status: ASSIGNED` message to the agent's branch (see schemas.md Section 5.3).
+5. Spawns the agent (sync) or commits a dispatch trigger (push-event).
 
 ### 6.2 Agent Execution
 
@@ -214,16 +275,16 @@ The agent:
 1. Reads `identity.md` for self-reference.
 2. Reads `AGENT.json` for assignment config, scope, and budget.
 3. Works exclusively within `worktree/`.
-4. Commits deliverable changes with required trailers.
+4. Commits deliverable changes with required trailers, including `Heartbeat` at least every 5 minutes.
 5. Does NOT create or modify any files outside `worktree/` (the orchestrator owns the assignment directory).
 
 ### 6.3 Complete Assignment
 
 On completion:
-1. The agent's final commit carries `Task-Status: COMPLETED`.
-2. The orchestrator integrates the agent's branch into the target repo (per LOOM v1 Section 5.3).
+1. The agent's final commit carries `Task-Status: COMPLETED` with required trailers (`Files-Changed`, at least one `Key-Finding`).
+2. The orchestrator integrates the agent's branch into the target repo (see protocol.md Section 5.3).
 3. The worktree MAY be removed. The assignment directory (with AGENT.json) is retained for audit.
-4. The agent's branch is retained per LOOM v1 retention policy (default 30 days).
+4. The agent's branch is retained per retention policy (default 30 days).
 
 ### 6.4 Cleanup
 
@@ -235,38 +296,15 @@ Completed assignment directories are archived, not deleted. The orchestrator MAY
 
 An implementation conforms to this spec if:
 
-1. **Separation**: AGENT.json is never committed to the agent's code branch. Protocol files (TASK.md, PLAN.md, STATUS.md, MEMORY.md) are never present in the worktree.
+1. **Separation**: AGENT.json is never committed to the agent's code branch. No protocol files (TASK.md, PLAN.md, STATUS.md, MEMORY.md) are present in the worktree.
 2. **Identity persistence**: `identity.md` exists before the first assignment and survives after all assignments are cleaned up.
 3. **Assignment isolation**: Each assignment has its own directory, its own AGENT.json, and its own worktree. No sharing.
 4. **Worktree purity**: The worktree contains only files intended for the target repository. `git status` in the worktree shows no protocol artifacts.
-5. **Commit protocol**: Every agent commit includes `Agent-Id`, `Session-Id`, and `Task-Status` trailers.
+5. **Commit protocol**: Every agent commit includes `Agent-Id`, `Session-Id` trailers. State-transition commits include `Task-Status`. Agents commit `Heartbeat` at least every 5 minutes.
 6. **Scope enforcement**: The orchestrator rejects integration of commits modifying files outside `scope.paths_allowed` or inside `scope.paths_denied`.
-7. **Naming convention**: Assignment directories follow the `<sequence>-<slug>` pattern.
+7. **Naming convention**: Assignment directories follow the `<sequence>-<slug>` pattern. Branches follow `loom/<agent>-<slug>`.
+8. **Orchestrator accountability**: Orchestrator commits after terminal state use `chore(loom):` and carry no `Task-Status` trailer.
 
 ---
 
-## 8. Migration from LOOM v1
-
-### 8.1 Agent Identity
-
-Move agent identities from project-specific locations (e.g., `agents/<name>/identity.md`) to `.mcagent/agents/<name>/identity.md`. The content is unchanged.
-
-### 8.2 Protocol Files
-
-LOOM v1 protocol files (TASK.md, PLAN.md, STATUS.md, MEMORY.md) are no longer committed to agent branches. Their contents are encoded in commit messages and trailers. Existing branches with protocol files are valid under v1 but non-conformant under this spec.
-
-### 8.3 AGENT.json
-
-Move from worktree root to `.mcagent/agents/<name>/<assignment>/AGENT.json`. Add the new fields (`assignment_id`, `repo`, `base_ref`, `dispatch`). Existing fields are backward-compatible.
-
-### 8.4 Worktree Layout
-
-LOOM v1 worktrees were standalone directories. Under this spec, worktrees are nested inside assignment directories. Existing worktrees can be adopted by creating the assignment directory structure around them.
-
-### 8.5 Coexistence
-
-During migration, both conventions MAY coexist. The orchestrator SHOULD detect which convention an agent branch uses by checking for the presence of protocol files in the worktree root. If present, treat as v1. If absent, treat as v2.
-
----
-
-*End of `.mcagent/` directory specification v0.1.0.*
+*End of `.mcagent/` directory specification — loom/1 1.0.0-draft.*

--- a/.claude/skills/loom/references/protocol.md
+++ b/.claude/skills/loom/references/protocol.md
@@ -1,378 +1,177 @@
-# LOOM Protocol Reference (Skill Edition)
+# LOOM Protocol Reference
 
-**Version**: 1.0 | **Status**: Draft | **License**: CC-BY-4.0 (spec), Apache-2.0 (implementations)
+**Version**: 1.0.0-draft | **Protocol**: `loom/1` | **Status**: Draft
 
 LOOM defines how AI agents coordinate through version control. Agents work in isolated git worktrees; an orchestrator serializes integration into a shared workspace. Key words: MUST, MUST NOT, SHOULD, MAY per RFC 2119.
 
----
-
-## 2. Concepts
-
-| Concept          | Definition |
-|------------------|------------|
-| **Agent**        | An isolated process that reads a task, edits files in a worktree, commits to its own branch, and reports status. |
-| **Orchestrator** | The sole entity that creates agents, reviews plans, integrates work into the workspace, and manages lifecycle. |
-| **Worktree**     | A git worktree (created via `git worktree add`) providing filesystem isolation for one agent. |
-| **Workspace**    | The primary working tree of the repository. Only the orchestrator writes here. |
-| **Entry**        | A structured knowledge record persisted in git, identified by content hash. |
-
-Five concepts. Nothing else is a protocol-level type.
+The authoritative directory specification is `mcagent-spec.md`. This document defines the lifecycle state machine, operations, error model, security model, and coordination patterns.
 
 ---
 
-## 3. Agent Lifecycle State Machine
+## 1. Concepts
 
-An agent is always in exactly one state. Transitions are triggered by the
-agent or the orchestrator as noted. Invalid transitions MUST be rejected.
+| Concept | Definition |
+|---------|-----------|
+| **Agent** | An isolated process that reads a task, edits files in a worktree, commits to its own branch, and reports status via commit trailers. |
+| **Orchestrator** | The sole entity (`bitswell`) that creates agents, reviews plans, integrates work into the workspace, and manages `.mcagent/`. |
+| **Worktree** | A git worktree providing filesystem isolation for one agent. Contains only deliverable code. |
+| **Workspace** | The primary working tree of the repository. Only the orchestrator writes here. |
+| **Assignment** | A task given to an agent, tracked in `.mcagent/agents/<name>/<assignment>/`. |
+
+---
+
+## 2. Agent Lifecycle State Machine
+
+An agent is always in exactly one state. Transitions are triggered by the agent or the orchestrator as noted. Invalid transitions MUST be rejected.
 
 ```
                       +-----------+
-         spawn ------>| PLANNING  |------> FAILED
+         assign ----->|IMPLEMENTING|-------> FAILED
                       +-----------+          ^
-                           |                 |
-                    approve (orchestrator)    |
-                           |                 |
-                           v                 |
-                      +-----------+          |
-                      |IMPLEMENTING|-------->+
-                      +-----------+          |
                         |       |            |
                         |       +-> BLOCKED -+
                         v            |
                    +-----------+     |
-                   | COMPLETED |<----+ (unblock)
+                   | COMPLETED |<----+ (via IMPLEMENTING)
                    +-----------+
 ```
 
 ### Transition table
 
-| From           | To             | Trigger      | Guard |
-|----------------|----------------|--------------|-------|
-| (none)         | PLANNING       | orchestrator spawns agent | TASK.md exists in worktree |
-| PLANNING       | IMPLEMENTING   | orchestrator approves plan | PLAN.md committed; all agents have reached PLANNING or later |
-| PLANNING       | FAILED         | agent or orchestrator | -- |
-| IMPLEMENTING   | COMPLETED      | agent | STATUS.md committed with `status: completed`; MEMORY.md exists |
-| IMPLEMENTING   | BLOCKED        | agent | STATUS.md updated with `status: blocked` and `blocked_reason` |
-| IMPLEMENTING   | FAILED         | agent or orchestrator | STATUS.md updated with error fields |
-| BLOCKED        | IMPLEMENTING   | orchestrator resolves blocker | orchestrator updates TASK.md with resolution |
-| BLOCKED        | FAILED         | orchestrator timeout | heartbeat age > configured threshold |
-| COMPLETED      | (terminal)     | -- | -- |
-| FAILED         | (terminal)     | -- | -- |
+| From | To | Trigger | Guard |
+|------|-----|---------|-------|
+| (none) | ASSIGNED | orchestrator creates branch + commit | AGENT.json exists in assignment dir |
+| ASSIGNED | IMPLEMENTING | agent's first commit | Branch exists, task commit present |
+| IMPLEMENTING | COMPLETED | agent | Final commit has `Task-Status: COMPLETED`, `Files-Changed`, `Key-Finding` |
+| IMPLEMENTING | BLOCKED | agent | Commit has `Task-Status: BLOCKED` and `Blocked-Reason` |
+| IMPLEMENTING | FAILED | agent or orchestrator | Commit has `Task-Status: FAILED`, `Error-Category`, `Error-Retryable` |
+| BLOCKED | IMPLEMENTING | orchestrator resolves blocker | Orchestrator updates task context |
+| BLOCKED | FAILED | orchestrator timeout | Heartbeat age > configured threshold |
+| COMPLETED | (terminal) | -- | -- |
+| FAILED | (terminal) | -- | -- |
 
-The orchestrator MAY spawn a new agent to retry failed work. This is a
-new agent, not a state transition of the old one.
+The orchestrator MAY spawn a new agent to retry failed work. This is a new agent, not a state transition of the old one.
 
----
-
-## 4. Directory Convention
-
-### 4.0 Convention Versions
-
-Two directory conventions exist. Implementations MUST support at least one.
-
-| Version | Identifier | Protocol files in worktree | Agent metadata location |
-|---------|-----------|---------------------------|------------------------|
-| v1 (this section) | `loom/1` | Yes (TASK.md, PLAN.md, STATUS.md, MEMORY.md, AGENT.json) | Worktree root |
-| v2 (`.mcagent/`) | `loom/2` | No -- protocol state in commit messages | `.mcagent/agents/<name>/<assignment>/AGENT.json` |
-
-The orchestrator detects the active convention by checking `protocol_version`
-in AGENT.json. When `loom/2`, the `.mcagent/` directory spec governs layout.
-See `mcagent-spec.md` for the full v2 specification.
-
-### 4.0.1 v2 Summary
-
-Under v2, the worktree contains ONLY deliverable code. Protocol state moves to:
-- **Agent config**: `.mcagent/agents/<name>/<assignment>/AGENT.json` (outside worktree)
-- **Lifecycle state**: Commit message trailers (`Task-Status`, `Agent-Id`, `Session-Id`)
-- **Agent identity**: `.mcagent/agents/<name>/identity.md` (persistent across assignments)
-
-The v1 convention below remains valid for `loom/1` agents.
+**Orchestrator post-terminal commits**: The orchestrator MAY commit to an agent's branch after terminal state (e.g., hotfixes before integration). These commits use `chore(loom):` type and carry NO `Task-Status` trailer. They are outside the state machine.
 
 ---
 
-### 4.1 v1 Convention (Original)
+## 3. Operations
 
-Each agent works in a dedicated worktree. The orchestrator creates this
-directory before spawning the agent.
-
-```
-<worktree-root>/
-  TASK.md            # Written by orchestrator. Immutable during agent run.
-  PLAN.md            # Written by agent during PLANNING.
-  STATUS.md          # Written by agent. See Section 4.1.
-  MEMORY.md          # Written by agent. See Section 4.2.
-  AGENT.json         # Written by orchestrator at spawn. See Section 4.3.
-```
-
-All five files are committed to the agent's branch. This makes status
-changes atomic (a commit either happened or it did not) and auditable
-(git log is the audit trail).
-
-### 4.1 STATUS.md
-
-YAML front matter delimited by `---`. Parsers MUST handle this as YAML.
-
-```yaml
----
-status: <PLANNING|IMPLEMENTING|COMPLETED|BLOCKED|FAILED>
-updated_at: <ISO-8601 UTC>
-heartbeat_at: <ISO-8601 UTC>
-branch: <branch-name>
-base_commit: <sha>
-files_changed: <integer>
-summary: <one-line description>
-error:
-  category: <task_unclear|blocked|resource_limit|conflict|internal>
-  message: <human-readable detail>
-  retryable: <true|false>
-blocked_reason: <string, present only when status is BLOCKED>
-budget:
-  tokens_used: <integer>
-  tokens_limit: <integer>
-  cost_usd: <float, optional>
----
-```
-
-The `error` block is REQUIRED when status is FAILED. The `budget` block
-is REQUIRED at Level 2+.
-
-Agents MUST update `heartbeat_at` and commit at least every 5 minutes
-while running. This is the liveness signal.
-
-### 4.2 MEMORY.md
-
-Markdown with required sections:
-
-```markdown
-## Key Findings
-- <finding relevant to downstream agents>
-
-## Decisions
-- **<decision>**: <rationale>
-
-## Deviations from Plan
-- <what changed and why>
-```
-
-Agents SHOULD write MEMORY.md incrementally during work, not only at
-completion. This serves as a checkpoint if the agent is terminated.
-
-### 4.3 AGENT.json
-
-Written by the orchestrator. Read-only for the agent.
-
-```json
-{
-  "agent_id": "<unique string>",
-  "session_id": "<uuid, unique per invocation>",
-  "protocol_version": "loom/1",
-  "context_window_tokens": <integer>,
-  "token_budget": <integer>,
-  "dependencies": ["<agent-id>", ...],
-  "scope": {
-    "paths_allowed": ["<glob>", ...],
-    "paths_denied": ["<glob>", ...]
-  },
-  "timeout_seconds": <integer>
-}
-```
-
-`scope` defines which file paths the agent is permitted to modify.
-The orchestrator MUST reject commits that modify files outside scope
-during integration.
-
----
-
-## 5. Operations
-
-The protocol has four operations. Implementations bind these to
-tool-specific commands.
-
-### 5.1 assign(orchestrator, agent, task) -> worktree
+### 3.1 assign(orchestrator, agent, task) -> worktree
 
 The orchestrator:
-1. Creates a git worktree branching from the workspace HEAD.
-2. Writes TASK.md and AGENT.json into the worktree.
-3. Commits both files to the agent's branch.
-4. Spawns the agent process in the worktree.
+1. Creates `.mcagent/agents/<name>/<assignment>/` with AGENT.json.
+2. Creates a git worktree branching from `base_ref`.
+3. Commits the task description to the agent's branch with `Task-Status: ASSIGNED` trailers.
+4. Spawns the agent (sync) or pushes the branch for dispatch (push-event).
 
-**Precondition**: Agent count < `max_agents` configuration.
-**Postcondition**: Agent is in PLANNING state.
+**Precondition**: AGENT.json written. Worktree created.
+**Postcondition**: Agent's branch has an ASSIGNED commit.
 
-### 5.2 commit(agent, changes) -> sha
+### 3.2 commit(agent, changes) -> sha
 
-The agent commits work to its own branch. Every commit MUST include:
+The agent commits work to its own branch. Every commit MUST include `Agent-Id` and `Session-Id` trailers. State-transition commits also include `Task-Status`.
 
-```
-<type>(<scope>): <subject>
+Agents MUST commit a `Heartbeat` trailer at least every 5 minutes while running. This is the liveness signal.
 
-<body>
-
-Agent-Id: <agent-id>
-Session-Id: <session-id>
-```
-
-The `Agent-Id` and `Session-Id` trailers are REQUIRED on every commit.
-Type values follow Conventional Commits (feat, fix, docs, refactor,
-test, chore).
-
-**Precondition**: Agent is in PLANNING or IMPLEMENTING.
+**Precondition**: Agent is IMPLEMENTING.
 **Postcondition**: Branch HEAD advances.
 
-### 5.3 integrate(orchestrator, agent) -> result
+### 3.3 integrate(orchestrator, agent) -> result
 
-The orchestrator merges an agent's branch into the workspace. This is
-the critical section. Integration is sequential and atomic: if it fails
-at any point, the workspace is left in its pre-integration state.
+The orchestrator merges an agent's branch into the workspace. Integration is sequential and atomic.
 
 Steps:
-1. Verify agent status is COMPLETED.
-2. Verify `base_commit` in STATUS.md is an ancestor of workspace HEAD.
-3. Verify all files changed are within the agent's `scope`.
-4. Attempt merge. On conflict: set result to `conflict`, do not modify workspace.
-5. Run project validation (tests, linting -- project-defined, not protocol-defined).
-6. If validation passes: commit to workspace. If not: set result to `validation_failed`.
+1. Verify agent's latest `Task-Status` is COMPLETED.
+2. Verify all files changed are within the agent's `scope`.
+3. Attempt merge. On conflict: abort, do not modify workspace.
+4. Run project validation (tests, linting -- project-defined).
+5. If validation passes: commit. If not: result is `validation_failed`.
 
 **Precondition**: Agent is COMPLETED. Dependencies are integrated.
 **Postcondition**: Workspace HEAD advances, or result indicates failure.
 
-### 5.4 store(agent, entry) -> id
-
-The agent records a knowledge entry. At Level 1, this is writing to
-MEMORY.md. At Level 2, this additionally creates a content-addressed
-git ref at `refs/loom/memory/<agent-id>/<entry-id>`.
-
-`store` is idempotent: storing the same content twice produces the same
-ref (content-addressed).
-
 ---
 
-## 6. Error Model
+## 4. Error Model
 
-### 6.1 Error categories
+### 4.1 Error categories
 
-| Category         | Meaning | Retryable | Example |
-|------------------|---------|-----------|---------|
-| `task_unclear`   | Agent cannot interpret the task | No | Ambiguous requirements |
-| `blocked`        | External dependency not met | Yes, when unblocked | Waiting on upstream agent |
-| `resource_limit` | Context window, budget, or time exhausted | Maybe, with more budget | Token limit hit |
-| `conflict`       | Integration merge conflict | Yes, after rebase | Two agents modified same file |
-| `internal`       | Unexpected failure | Maybe | Crash, git corruption |
+| Category | Meaning | Retryable | Example |
+|----------|---------|-----------|---------|
+| `task_unclear` | Agent cannot interpret the task | No | Ambiguous requirements |
+| `blocked` | External dependency not met | Yes, when unblocked | Waiting on upstream agent |
+| `resource_limit` | Context window, budget, or time exhausted | Maybe | Token limit hit |
+| `conflict` | Integration merge conflict | Yes, after rebase | Two agents modified same file |
+| `internal` | Unexpected failure | Maybe | Crash, git corruption |
 
-### 6.2 Exit codes
-
-| Code | Meaning |
-|------|---------|
-| 0    | Success. STATUS.md is COMPLETED. |
-| 1    | Failure. STATUS.md is FAILED with error fields. |
-| 2    | Catastrophic. STATUS.md may not have been written. Orchestrator must inspect worktree. |
-
-### 6.3 Recovery
-
-The orchestrator MUST handle each error category:
+### 4.2 Recovery
 
 - `task_unclear`: Escalate to human. Do not retry automatically.
 - `blocked`: Wait for dependency, then transition agent to IMPLEMENTING.
 - `resource_limit`: May retry with increased budget or decompose task.
-- `conflict`: Rebase agent branch onto new workspace HEAD. Retry agent.
+- `conflict`: Rebase agent branch onto new workspace HEAD. Spawn new agent to verify.
 - `internal`: Preserve worktree for post-mortem. May retry with new agent.
 
-Failed agent branches MUST NOT be deleted. They are archived after a
-configurable retention period (default: 30 days).
+Failed agent branches MUST NOT be deleted. Retained for 30 days minimum.
 
 ---
 
-## 7. Security Model
+## 5. Security Model
 
-### 7.1 Trust boundary
+### 5.1 Trust boundary
 
 | Boundary | Rule |
 |----------|------|
 | Workspace write | Only the orchestrator writes to the workspace. Agents MUST NOT. |
-| Agent scope | An agent may modify only files matching its `scope` in AGENT.json. The orchestrator verifies this at integration. |
-| Cross-agent isolation | An agent MUST NOT write to another agent's worktree. Read access to peer STATUS.md and MEMORY.md is permitted. |
+| Agent scope | An agent may modify only files matching its `scope` in AGENT.json. The orchestrator verifies at integration. |
+| Cross-agent isolation | An agent MUST NOT write to another agent's worktree. |
+| `.mcagent/` ownership | Only the orchestrator writes to `.mcagent/`. Agents read only their own AGENT.json and identity. |
 
-### 7.2 Input validation
+### 5.2 Input validation
 
-- The orchestrator MUST validate STATUS.md against the YAML schema before acting on it.
+- The orchestrator MUST validate commit trailers before acting on them.
 - External input (PR comments, issues) MUST be treated as untrusted.
-- Peer MEMORY.md is informational, not instructional. TASK.md is the authoritative instruction source.
-
-### 7.3 Resource limits
-
-| Resource | Default Limit | Enforced By |
-|----------|--------------|-------------|
-| Concurrent agents | 10 | Orchestrator |
-| Worktree disk | 5 GB | Orchestrator monitoring |
-| Branches per agent | 3 | Orchestrator |
-| Memory entries per agent | 1,000 | Orchestrator or tooling |
-| Agent timeout | 3600 seconds | Orchestrator (heartbeat check) |
+- Prompt files MUST use quoted heredocs (`<<'DELIM'`) to prevent shell injection.
 
 ---
 
-## 8. Coordination
+## 6. Coordination
 
-- **Orchestrator-to-agent**: TASK.md and AGENT.json (immutable after spawn). For feedback, the orchestrator appends a `## Feedback` section to TASK.md.
-- **Agent-to-orchestrator**: Agent commits STATUS.md and MEMORY.md. Orchestrator monitors the agent's branch HEAD.
-- **Agent-to-agent**: No direct communication. Agents MAY read peer STATUS.md and MEMORY.md (best-effort, tolerate stale data).
-- **Dependencies**: Declared in AGENT.json. The dependency graph MUST be a DAG (orchestrator rejects cycles). Integration proceeds in topological order.
-
----
-
-## 9. Observability
-
-### 9.1 Heartbeat
-
-Agents MUST update `heartbeat_at` in STATUS.md and commit at least
-every 5 minutes. The orchestrator considers an agent stale if
-`now - heartbeat_at > timeout_seconds`. Stale agents are terminated:
-SIGTERM, wait 10 seconds, then SIGKILL.
+- **Orchestrator-to-agent**: Task description in the ASSIGNED commit message. AGENT.json for config.
+- **Agent-to-orchestrator**: Agent commits with `Task-Status` trailers. `git log --format` is the query interface.
+- **Agent-to-agent**: No direct communication. Agents MAY read peer branches (best-effort, tolerate stale data).
+- **Dependencies**: Declared in AGENT.json. The dependency graph MUST be a DAG (orchestrator rejects cycles). Integration proceeds in topological order. Dependencies resolve via branch naming: `<agent>/<slug>` maps to `loom/<agent>-<slug>`.
 
 ---
 
-## 10. Context Window Management
+## 7. Observability
 
-Context exhaustion is the primary failure mode of LLM-based agents. The
-protocol addresses it directly.
+### 7.1 Heartbeat
 
-### 10.1 Budget declaration
+Agents MUST include a `Heartbeat: <ISO-8601 UTC>` trailer and commit at least every 5 minutes while running. The orchestrator considers an agent stale if no commit appears within `timeout_seconds`. Stale agents are terminated.
 
-AGENT.json declares `context_window_tokens` and `token_budget`. The
-orchestrator MUST size tasks to fit within the agent's context window.
+### 7.2 Audit trail
 
-### 10.2 Incremental checkpointing
-
-Agents MUST write MEMORY.md incrementally (not only at completion). If
-the agent's context is compacted, it re-reads TASK.md, AGENT.json, and
-MEMORY.md to recover state. These three files are the minimum recovery
-set.
-
-### 10.3 Budget reservation
-
-Agents MUST reserve at least 10% of `token_budget` for:
-- Final MEMORY.md update
-- Final STATUS.md update
-- Final commit
-
-If the agent detects it has consumed 90% of its budget, it MUST write
-current state to MEMORY.md, set STATUS.md to `BLOCKED` with
-`blocked_reason: resource_limit`, commit, and exit with code 1.
+Every state change is a commit. `git log` is the complete audit trail. Commit trailers provide structured metadata for automated queries. See `schemas.md` for extraction queries.
 
 ---
 
-## 11. Conformance: Level 1 Checklist
+## 8. Context Window Management
 
-Level 1 (Convention Agent) -- target: under 100 lines to implement.
+### 8.1 Budget declaration
 
-MUST:
-- Work in an isolated git worktree
-- Commit with `Agent-Id` and `Session-Id` trailers
-- Write STATUS.md with valid YAML front matter on every state change
-- Write MEMORY.md with the three required sections
-- Update `heartbeat_at` at least every 5 minutes
-- Exit with code 0 on success, 1 on failure
-- Respect `scope` from AGENT.json (honor path restrictions)
+AGENT.json declares `context_window_tokens` and `token_budget`. The orchestrator MUST size tasks to fit within the agent's context window.
+
+### 8.2 Incremental checkpointing
+
+Agents MUST commit findings incrementally (via `Key-Finding`, `Decision`, `Deviation` trailers). If the agent's context is compacted, it re-reads AGENT.json and its own commit history to recover state.
+
+### 8.3 Budget reservation
+
+Agents MUST reserve at least 10% of `token_budget` for the final commit (status + findings + trailers). At 90% consumption, the agent MUST commit current state with `Task-Status: BLOCKED` and `Blocked-Reason: resource_limit`, then exit.
 
 ---
 
-*End of LOOM 1.0 skill reference.*
+*End of LOOM Protocol Reference v1.0.0-draft.*

--- a/.claude/skills/loom/references/schemas.md
+++ b/.claude/skills/loom/references/schemas.md
@@ -1,242 +1,62 @@
-# LOOM File Format Schemas
+# LOOM Schemas Reference
 
-Reference for all file formats used by the LOOM protocol (version `loom/1`).
-Two independent implementations reading this document MUST produce interoperable artifacts.
+**Version**: 1.0.0-draft | **Protocol**: `loom/1` | **Status**: Draft
 
----
+Defines AGENT.json schema, commit message format, branch naming, commit-based protocol (trailer vocabulary, state requirements, templates, extraction queries, validation rules).
 
-## 1. TASK.md Template
-
-Written by the orchestrator. Immutable after agent spawn.
-
-```markdown
-# Task: <short title>
-
-## Objective
-<What the agent must accomplish. One paragraph.>
-
-## Context
-<Background the agent needs: relevant code, prior decisions, links to specs.>
-
-## Scope
-- **Allowed paths**: <glob list, e.g. `src/config/**`, `tests/config/**`>
-- **Denied paths**: <glob list, e.g. `src/auth/**`>
-
-## Acceptance Criteria
-- [ ] <Criterion 1 -- measurable, verifiable>
-- [ ] <Criterion 2>
-
-## Dependencies
-- <agent-id that must complete before this agent can be integrated, or "none">
-
-## Constraints
-- **Token budget**: <integer, e.g. 100000>
-- **Timeout**: <seconds, e.g. 3600>
-```
-
-All sections are REQUIRED. The orchestrator MAY append a `## Feedback` section after spawn to communicate plan-review results; the original sections remain unchanged.
+See `mcagent-spec.md` for directory layout. See `protocol.md` for lifecycle state machine and operations.
 
 ---
 
-## 2. AGENT.json Schema
+## 1. AGENT.json Schema
 
-Written by the orchestrator at spawn. Read-only for the agent.
+Written by the orchestrator at assignment creation. Lives at `.mcagent/agents/<name>/<assignment>/AGENT.json` — outside the worktree. Read-only for the agent.
 
 ```json
 {
-  "agent_id":              "<string, unique, kebab-case, e.g. \"config-parser\">",
-  "session_id":            "<string, UUID v4, unique per invocation>",
-  "protocol_version":      "loom/1",
-  "context_window_tokens": "<integer, > 0, model context size in tokens>",
-  "token_budget":          "<integer, > 0, max tokens the agent may consume>",
-  "dependencies":          ["<agent-id>"],
+  "agent_id": "<agent-name>",
+  "assignment_id": "<sequence>-<slug>",
+  "session_id": "<uuid-v4>",
+  "protocol_version": "loom/1",
+  "repo": "<org>/<repo>",
+  "base_ref": "<branch-or-sha>",
+  "context_window_tokens": 200000,
+  "token_budget": 100000,
+  "dependencies": [],
   "scope": {
-    "paths_allowed":       ["<glob>"],
-    "paths_denied":        ["<glob>"]
+    "paths_allowed": ["."],
+    "paths_denied": []
   },
-  "timeout_seconds":       "<integer, > 0, default 3600>"
+  "timeout_seconds": 3600,
+  "dispatch": {
+    "mode": "sync",
+    "trigger_ref": ""
+  }
 }
 ```
-
-**Field constraints:**
 
 | Field | Type | Required | Constraints |
 |-------|------|----------|-------------|
-| `agent_id` | string | yes | Kebab-case (`[a-z0-9]+(-[a-z0-9]+)*`), unique within the repository |
-| `session_id` | string | yes | UUID v4, unique per agent invocation |
+| `agent_id` | string | yes | Kebab-case (`[a-z0-9]+(-[a-z0-9]+)*`) |
+| `assignment_id` | string | yes | Matches the assignment directory name |
+| `session_id` | string | yes | UUID v4, unique per invocation |
 | `protocol_version` | string | yes | Literal `"loom/1"` |
+| `repo` | string | yes | Target repo in `<org>/<repo>` format |
+| `base_ref` | string | yes | Branch or commit SHA |
 | `context_window_tokens` | integer | yes | Positive integer |
 | `token_budget` | integer | yes | Positive integer, <= `context_window_tokens` |
-| `dependencies` | string[] | yes | Array of valid `agent_id` values (may be empty `[]`). Graph MUST be a DAG. |
-| `scope.paths_allowed` | string[] | yes | Non-empty array of globs relative to repo root |
-| `scope.paths_denied` | string[] | yes | Array of globs (may be empty `[]`). Deny takes precedence over allow. |
-| `timeout_seconds` | integer | yes | Positive integer. Default: 3600 |
-
-**Example (filled):**
-
-```json
-{
-  "agent_id": "config-parser",
-  "session_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-  "protocol_version": "loom/1",
-  "context_window_tokens": 200000,
-  "token_budget": 150000,
-  "dependencies": [],
-  "scope": {
-    "paths_allowed": ["src/config/**", "tests/config/**"],
-    "paths_denied": ["src/config/secrets.rs"]
-  },
-  "timeout_seconds": 3600
-}
-```
+| `dependencies` | string[] | yes | Array of `<agent>/<slug>` refs. Graph MUST be a DAG. |
+| `scope.paths_allowed` | string[] | yes | Globs relative to worktree root. `["."]` means full access. |
+| `scope.paths_denied` | string[] | yes | Globs. Deny takes precedence. May be empty `[]`. |
+| `timeout_seconds` | integer | yes | Default: 3600 |
+| `dispatch.mode` | string | yes | `"sync"` or `"push-event"` |
+| `dispatch.trigger_ref` | string | conditional | Required when mode is `"push-event"` |
 
 ---
 
-## 3. STATUS.md YAML Schema
+## 2. Commit Message Format
 
-> **Level 1 only.** At Level 2+, protocol state moves to commit trailers (Section 8). STATUS.md is not used.
-
-YAML front matter delimited by `---`. Parsers MUST treat the block as YAML, not freeform text. Markdown body after the closing `---` is permitted but not parsed by the protocol.
-
-**Full field listing:**
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `status` | enum | always | One of: `PLANNING`, `IMPLEMENTING`, `COMPLETED`, `BLOCKED`, `FAILED` |
-| `updated_at` | string | always | ISO-8601 UTC timestamp (e.g. `2026-04-02T14:30:00Z`) |
-| `heartbeat_at` | string | always | ISO-8601 UTC timestamp. MUST be updated and committed at least every 5 minutes while the agent is running. |
-| `branch` | string | always | The agent's branch name (e.g. `loom/config-parser`) |
-| `base_commit` | string | always | SHA of the commit the agent's worktree was created from |
-| `files_changed` | integer | when `COMPLETED` | Number of files modified by the agent |
-| `summary` | string | always | One-line human-readable description of current state |
-| `error` | object | when `FAILED` | See error sub-fields below |
-| `error.category` | enum | when `FAILED` | One of: `task_unclear`, `blocked`, `resource_limit`, `conflict`, `internal` |
-| `error.message` | string | when `FAILED` | Human-readable detail |
-| `error.retryable` | boolean | when `FAILED` | Whether the orchestrator may retry |
-| `blocked_reason` | string | when `BLOCKED` | Why the agent cannot proceed |
-| `budget` | object | Level 2+ | Token/cost tracking |
-| `budget.tokens_used` | integer | Level 2+ | Tokens consumed so far |
-| `budget.tokens_limit` | integer | Level 2+ | Token ceiling from AGENT.json |
-| `budget.cost_usd` | float | optional | Estimated monetary cost |
-
-**Validation rules:**
-- `error` block is REQUIRED when `status` is `FAILED`; MUST NOT be present otherwise.
-- `blocked_reason` is REQUIRED when `status` is `BLOCKED`; MUST NOT be present otherwise.
-- `files_changed` is REQUIRED when `status` is `COMPLETED`.
-- `budget` block is REQUIRED at Level 2+; optional at Level 1.
-
-**Example -- PLANNING state:**
-
-```yaml
----
-status: PLANNING
-updated_at: "2026-04-02T14:00:00Z"
-heartbeat_at: "2026-04-02T14:00:00Z"
-branch: loom/config-parser
-base_commit: abc1234def5678
-summary: Drafting implementation plan
----
-```
-
-**Example -- COMPLETED state:**
-
-```yaml
----
-status: COMPLETED
-updated_at: "2026-04-02T15:12:00Z"
-heartbeat_at: "2026-04-02T15:12:00Z"
-branch: loom/config-parser
-base_commit: abc1234def5678
-files_changed: 4
-summary: Config parser implemented with tests
-budget:
-  tokens_used: 87000
-  tokens_limit: 150000
-  cost_usd: 0.42
----
-```
-
-**Example -- FAILED state:**
-
-```yaml
----
-status: FAILED
-updated_at: "2026-04-02T14:45:00Z"
-heartbeat_at: "2026-04-02T14:45:00Z"
-branch: loom/config-parser
-base_commit: abc1234def5678
-summary: Token budget exhausted before completion
-error:
-  category: resource_limit
-  message: "Consumed 90% of token budget during implementation phase"
-  retryable: true
----
-```
-
----
-
-## 4. MEMORY.md Template
-
-> **Level 1 only.** At Level 2+, memory is encoded as commit trailers (Section 8.5). MEMORY.md is not used.
-
-Written by the agent. MUST be updated incrementally during work, not only at completion. Serves as the checkpoint for context-window recovery: an agent whose context is compacted re-reads TASK.md, AGENT.json, and MEMORY.md.
-
-```markdown
-## Key Findings
-- <Facts discovered during work that downstream agents or the orchestrator need.>
-- <E.g., "The config module uses TOML, not YAML as documented.">
-
-## Decisions
-- **<Decision>**: <Rationale>
-- **<E.g., Used serde_derive over manual impl>**: <Reduces boilerplate, all fields are simple types.>
-
-## Deviations from Plan
-- <What changed from PLAN.md and why.>
-- <E.g., "Added src/config/defaults.rs (not in plan) to hold fallback values.">
-```
-
-All three sections are REQUIRED. Sections may be empty (`- (none yet)`) during early work but MUST contain substantive entries before the agent sets status to `COMPLETED`.
-
----
-
-## 5. PLAN.md Template
-
-> **Level 1 only.** At Level 2+, the plan is the commit body of the agent's first work commit. PLAN.md is not used.
-
-Written by the agent during the PLANNING state. MUST be committed before the agent can transition to IMPLEMENTING.
-
-```markdown
-# Plan: <task title>
-
-## Approach
-<High-level strategy in 2-3 sentences.>
-
-## Steps
-1. <Step with concrete action, e.g. "Create `src/config/parser.rs` with public `parse()` function">
-2. <Next step>
-3. ...
-
-## Files to Modify
-- `<path>` -- <what changes and why>
-- `<path>` -- <what changes and why>
-
-## Risks
-- <What could go wrong and how you will handle it.>
-
-## Estimated Effort
-- **Tokens**: <estimated token usage, e.g. ~80,000>
-- **Files**: <count of files to create or modify>
-```
-
-All sections are REQUIRED. The orchestrator reviews this file before approving the transition to IMPLEMENTING.
-
----
-
-## 6. Commit Message Format
-
-All agent commits MUST use Conventional Commits format with trailers. This section defines the base format. Section 8 defines the full trailer vocabulary per state.
-
-**Base format:**
+All agent and orchestrator commits MUST use Conventional Commits with required trailers.
 
 ```
 <type>(<scope>): <subject>
@@ -244,159 +64,152 @@ All agent commits MUST use Conventional Commits format with trailers. This secti
 <body -- optional, explains "why" not "what">
 
 Agent-Id: <agent-id>
-Session-Id: <session-id, UUID v4>
+Session-Id: <session-id>
+[Task-Status: <state>]
+[...additional trailers]
 ```
 
-**Type values:** `task`, `feat`, `fix`, `docs`, `refactor`, `test`, `chore`
+**Type values:** `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `task`
 
-- `task` -- orchestrator task-assignment commits (new in v2). Not used by agents.
-- `feat`, `fix`, `docs`, `refactor`, `test`, `chore` -- standard Conventional Commits types, used by agents.
+- `task` — orchestrator assignment commits (`Task-Status: ASSIGNED`)
+- `chore(loom)` — orchestrator post-terminal commits (no `Task-Status`)
+- Other types — agent work commits
 
-**Trailer rules:**
-
-- Trailers follow the git trailer convention: `Key: Value`, one per line, separated from the body by a blank line.
-- `Agent-Id` and `Session-Id` are REQUIRED on every commit (orchestrator and agent).
-- Additional trailers are defined per state in Section 8.
-- Trailer keys are case-sensitive. Use the exact casing specified.
-- Multi-value trailers: repeat the key on separate lines (e.g., multiple `Key-Finding:` trailers).
-
-**Good example:**
-
-```
-feat(config): add TOML parser with validation
-
-Supports nested tables and type coercion for string-to-int fields.
-
-Agent-Id: config-parser
-Session-Id: a1b2c3d4-e5f6-7890-abcd-ef1234567890
-Task-Status: IMPLEMENTING
-```
-
-**Bad example (missing trailers, vague subject):**
-
-```
-update stuff
-```
+Both `Agent-Id` and `Session-Id` are REQUIRED on every commit.
 
 ---
 
-## 7. Branch Naming Convention
+## 3. Branch Naming Convention
 
-**Pattern:** `loom/<agent-id>` or `loom/<agent-id>-<assignment>`
+**Pattern:** `loom/<agent>-<slug>`
 
-**Examples:**
-- `loom/config-parser`
-- `loom/ratchet-commit-schema`
+The branch name encodes the agent and assignment slug. Dependencies in AGENT.json use `<agent>/<slug>` format. To resolve: replace `/` with `-`, prepend `loom/`.
 
-**agent-id constraints:**
-- Kebab-case: matches `[a-z0-9]+(-[a-z0-9]+)*`
-- Unique within the repository at any given time
-- Maximum length: 63 characters (git ref component limit)
+| Dependency | Branch |
+|-----------|--------|
+| `ratchet/commit-schema` | `loom/ratchet-commit-schema` |
+| `moss/migrate-identities` | `loom/moss-migrate-identities` |
 
-Each agent works exclusively on its own branch. The orchestrator creates the branch at worktree creation time, branching from the current workspace HEAD. Agents MUST NOT push to or modify any other branch.
+**Constraints:**
+- Kebab-case: `[a-z0-9]+(-[a-z0-9]+)*`
+- Maximum length: 63 characters
+- One agent per branch, one branch per assignment
 
 ---
 
-## 8. Commit-Based Protocol
+## 4. Trailer Vocabulary
 
-> **Applies at Level 2+.** Replaces STATUS.md, PLAN.md, and MEMORY.md with commit message trailers. All protocol state is encoded in commits. The worktree contains only deliverable code.
+All trailers follow `git-interpret-trailers(1)` syntax.
 
-### 8.1 Design Principles
-
-1. **Git is the protocol.** Every state transition is a commit. No protocol files in the worktree.
-2. **Trailers are structured.** Parseable by `git log --format='%(trailers)'` and `git log --format='%(trailers:key=Task-Status)'`.
-3. **Commits are append-only.** State is determined by the latest commit with a `Task-Status` trailer, not by mutation.
-4. **Backward-compatible.** Level 1 file-based protocol remains valid. Level 2 commit-based protocol is a strict superset.
-
-### 8.2 Trailer Vocabulary
-
-All trailers beyond `Agent-Id` and `Session-Id` are OPTIONAL unless marked REQUIRED for a specific state.
+### 4.1 Universal trailers (every commit)
 
 | Trailer | Type | Description |
 |---------|------|-------------|
-| `Agent-Id` | string | Agent identifier. REQUIRED on every commit. |
-| `Session-Id` | string | UUID v4, unique per agent invocation. REQUIRED on every commit. |
-| `Task-Status` | enum | One of: `ASSIGNED`, `IMPLEMENTING`, `COMPLETED`, `BLOCKED`, `FAILED`. Present on state-transition commits. |
-| `Assigned-To` | string | Agent-id of the assignee. REQUIRED on `ASSIGNED` commits. |
-| `Assignment` | string | Assignment identifier (e.g., `2-commit-schema`). REQUIRED on `ASSIGNED` commits. |
-| `Scope` | string | Glob or path list defining allowed scope. REQUIRED on `ASSIGNED` commits. In v2, typically `"."` (agent owns its worktree). |
-| `Scope-Denied` | string | Glob or path list of denied paths within scope. OPTIONAL on `ASSIGNED` commits. Omit if no denials. |
-| `Dependencies` | string | Comma-separated `<agent>/<assignment>` refs or `none`. REQUIRED on `ASSIGNED` commits. |
-| `Budget` | integer | Token budget for the task. REQUIRED on `ASSIGNED` commits. |
-| `Files-Changed` | integer | Number of files modified. REQUIRED on `COMPLETED` commits. |
-| `Key-Finding` | string | A fact discovered during work. Repeatable. REQUIRED on `COMPLETED` commits (at least one). |
-| `Decision` | string | A non-obvious choice made during work, format: `<what> -- <why>`. Repeatable. OPTIONAL. |
-| `Deviation` | string | A departure from the original task spec, format: `<what> -- <why>`. Repeatable. OPTIONAL. |
-| `Blocked-Reason` | string | What is preventing progress. REQUIRED on `BLOCKED` commits. |
-| `Error-Category` | enum | One of: `task_unclear`, `blocked`, `resource_limit`, `conflict`, `internal`. REQUIRED on `FAILED` commits. |
-| `Error-Retryable` | boolean | `true` or `false`. REQUIRED on `FAILED` commits. |
+| `Agent-Id` | string | Agent name (e.g., `ratchet`, `bitswell`). Kebab-case. |
+| `Session-Id` | string | UUID v4. Unique per agent invocation. ASSIGNED commit carries orchestrator's session. |
 
-### 8.3 Required Trailers Per State
+### 4.2 State trailers
 
-#### ASSIGNED (orchestrator writes)
+| Trailer | Type | Description |
+|---------|------|-------------|
+| `Task-Status` | enum | One of: `ASSIGNED`, `IMPLEMENTING`, `COMPLETED`, `BLOCKED`, `FAILED` |
+| `Heartbeat` | string | ISO-8601 UTC timestamp. SHOULD appear on every commit while agent is running. |
+
+### 4.3 Assignment trailers (ASSIGNED commits only)
+
+| Trailer | Type | Description |
+|---------|------|-------------|
+| `Assigned-To` | string | Agent-id of the assignee. |
+| `Assignment` | string | Assignment identifier (e.g., `2-commit-schema`). |
+| `Scope` | string | Allowed paths (e.g., `.`). |
+| `Scope-Denied` | string | Denied paths. OPTIONAL. Omit if none. |
+| `Dependencies` | string | Comma-separated `<agent>/<slug>` refs or `none`. |
+| `Budget` | integer | Token budget. |
+
+### 4.4 Completion trailers (COMPLETED commits)
+
+| Trailer | Type | Description |
+|---------|------|-------------|
+| `Files-Changed` | integer | Files modified (>= 0). REQUIRED. |
+| `Key-Finding` | string | Important discovery. Repeatable. At least one REQUIRED. |
+| `Decision` | string | Non-obvious choice, format `<what> -- <why>`. Repeatable. OPTIONAL. |
+| `Deviation` | string | Departure from task spec, format `<what> -- <why>`. Repeatable. OPTIONAL. |
+
+### 4.5 Error trailers (BLOCKED and FAILED commits)
+
+| Trailer | Type | Description |
+|---------|------|-------------|
+| `Blocked-Reason` | string | What is preventing progress. REQUIRED on BLOCKED. |
+| `Error-Category` | enum | `task_unclear`, `blocked`, `resource_limit`, `conflict`, `internal`. REQUIRED on FAILED. |
+| `Error-Retryable` | boolean | `true` or `false`. REQUIRED on FAILED. |
+
+---
+
+## 5. Required Trailers Per State
+
+### 5.1 ASSIGNED (orchestrator writes)
 
 | Trailer | Required |
 |---------|----------|
-| `Agent-Id` | yes |
+| `Agent-Id` | yes (orchestrator's id: `bitswell`) |
 | `Session-Id` | yes |
-| `Task-Status` | yes -- value `ASSIGNED` |
+| `Task-Status` | yes — value `ASSIGNED` |
 | `Assigned-To` | yes |
 | `Assignment` | yes |
 | `Scope` | yes |
 | `Dependencies` | yes |
 | `Budget` | yes |
 
-#### IMPLEMENTING (agent writes)
+### 5.2 IMPLEMENTING (agent writes)
 
 | Trailer | Required |
 |---------|----------|
 | `Agent-Id` | yes |
 | `Session-Id` | yes |
-| `Task-Status` | yes -- value `IMPLEMENTING` |
+| `Task-Status` | yes — value `IMPLEMENTING` |
+| `Heartbeat` | yes |
 
-The agent's first commit MUST carry `Task-Status: IMPLEMENTING`. Subsequent work commits MAY omit `Task-Status` (the state is inherited from the most recent state-transition commit).
-
-#### COMPLETED (agent writes)
+### 5.3 COMPLETED (agent writes)
 
 | Trailer | Required |
 |---------|----------|
 | `Agent-Id` | yes |
 | `Session-Id` | yes |
-| `Task-Status` | yes -- value `COMPLETED` |
+| `Task-Status` | yes — value `COMPLETED` |
 | `Files-Changed` | yes |
 | `Key-Finding` | yes (at least one) |
-| `Decision` | no (recommended if non-obvious choices were made) |
-| `Deviation` | no (required if the implementation diverged from the task) |
+| `Heartbeat` | yes |
 
-#### BLOCKED (agent writes)
+### 5.4 BLOCKED (agent writes)
 
 | Trailer | Required |
 |---------|----------|
 | `Agent-Id` | yes |
 | `Session-Id` | yes |
-| `Task-Status` | yes -- value `BLOCKED` |
+| `Task-Status` | yes — value `BLOCKED` |
 | `Blocked-Reason` | yes |
 
-#### FAILED (agent writes)
+### 5.5 FAILED (agent writes)
 
 | Trailer | Required |
 |---------|----------|
 | `Agent-Id` | yes |
 | `Session-Id` | yes |
-| `Task-Status` | yes -- value `FAILED` |
+| `Task-Status` | yes — value `FAILED` |
 | `Error-Category` | yes |
 | `Error-Retryable` | yes |
 
-### 8.4 Commit Templates
+---
 
-#### Orchestrator: Task Assignment
+## 6. Commit Templates
+
+### 6.1 Orchestrator: Task Assignment
 
 ```
 task(<agent-id>): <short task description>
 
 <Full task description. This replaces TASK.md.
-Include objective, context, acceptance criteria.
-The commit body IS the task specification.>
+Include objective, context, acceptance criteria.>
 
 Agent-Id: bitswell
 Session-Id: <bitswell-session-id>
@@ -404,190 +217,153 @@ Task-Status: ASSIGNED
 Assigned-To: <agent-id>
 Assignment: <assignment-id>
 Scope: .
-Scope-Denied: <glob-or-path-list, omit if none>
-Dependencies: <agent/assignment refs, comma-separated, or "none">
+Scope-Denied: <paths, omit if none>
+Dependencies: <agent/slug refs, comma-separated, or "none">
 Budget: <integer>
 ```
 
-#### Agent: Start (first commit)
+### 6.2 Agent: Start (first commit)
 
 ```
-<type>(<scope>): <what this commit does>
-
-<Optional body.>
+chore(<scope>): begin <assignment description>
 
 Agent-Id: <agent-id>
 Session-Id: <session-id>
 Task-Status: IMPLEMENTING
+Heartbeat: <ISO-8601 UTC>
 ```
 
-#### Agent: Work Commits (intermediate)
+### 6.3 Agent: Work (intermediate commits)
 
 ```
-<type>(<scope>): <what this commit does>
+<type>(<scope>): <subject>
 
-<Optional body.>
+<body>
 
 Agent-Id: <agent-id>
 Session-Id: <session-id>
+Heartbeat: <ISO-8601 UTC>
 ```
 
-Work commits do not require `Task-Status`. The agent is implicitly in `IMPLEMENTING` state until a terminal trailer appears. Work commits MAY include `Key-Finding`, `Decision`, or `Deviation` trailers if the agent discovers something worth recording mid-task.
-
-#### Agent: Completion
+### 6.4 Agent: Completion
 
 ```
-<type>(<scope>): <what this final commit does>
+<type>(<scope>): <subject>
 
-<Summary of what was accomplished.>
+<body summarizing what was accomplished>
 
 Agent-Id: <agent-id>
 Session-Id: <session-id>
 Task-Status: COMPLETED
 Files-Changed: <integer>
-Key-Finding: <finding-1>
-Key-Finding: <finding-2>
-Decision: <choice -- rationale>
-Deviation: <change -- reason>
+Key-Finding: <discovery>
+Heartbeat: <ISO-8601 UTC>
 ```
 
-#### Agent: Blocked
+### 6.5 Agent: Blocked
 
 ```
 chore(<scope>): blocked -- <short reason>
 
-<Detailed explanation of what is blocking progress.>
+<Detailed explanation>
 
 Agent-Id: <agent-id>
 Session-Id: <session-id>
 Task-Status: BLOCKED
-Blocked-Reason: <description of blocker>
+Blocked-Reason: <description>
+Heartbeat: <ISO-8601 UTC>
 ```
 
-#### Agent: Failed
+### 6.6 Agent: Failed
 
 ```
 chore(<scope>): failed -- <short reason>
 
-<Detailed explanation of what went wrong.>
+<Detailed explanation>
 
 Agent-Id: <agent-id>
 Session-Id: <session-id>
 Task-Status: FAILED
-Error-Category: <task_unclear|blocked|resource_limit|conflict|internal>
+Error-Category: <category>
 Error-Retryable: <true|false>
 ```
 
-### 8.5 Memory and Findings Mapping
+### 6.7 Orchestrator: Post-Terminal (hotfix/amendment)
 
-In Level 1, agents recorded discoveries in MEMORY.md under three sections: Key Findings, Decisions, and Deviations. In Level 2, these map directly to trailers.
+```
+chore(loom): <description of change>
 
-| MEMORY.md Section | Trailer | When to Write |
-|-------------------|---------|---------------|
-| Key Findings | `Key-Finding: <text>` | On any commit where the agent discovers a fact relevant to downstream agents or the orchestrator. REQUIRED on `COMPLETED` commit. |
-| Decisions | `Decision: <what> -- <why>` | On the commit where the decision is made. Recommended on `COMPLETED` commit if not already recorded. |
-| Deviations from Plan | `Deviation: <what> -- <why>` | On the commit where the deviation occurs. Required on `COMPLETED` commit if the implementation diverged from the task specification. |
+<body>
 
-**Accumulation rule:** To reconstruct the full memory for an agent session, collect all `Key-Finding`, `Decision`, and `Deviation` trailers across all commits with matching `Session-Id`. The `COMPLETED` commit's trailers are the canonical summary; earlier trailers provide incremental context.
-
-**Query to extract all findings for a session:**
-
-```bash
-git log --format='%(trailers:key=Key-Finding,valueonly)' \
-  --grep='Session-Id: <session-id>' <branch>
+Agent-Id: bitswell
+Session-Id: <bitswell-session-id>
 ```
 
-### 8.6 State Extraction Queries
+Note: No `Task-Status` trailer. This commit is outside the state machine.
 
-These `git log` commands extract protocol state from commit history. All queries assume the agent's branch.
+---
 
-#### Current task status
+## 7. State Extraction Queries
 
 ```bash
+# Latest status of a branch
 git log -1 --format='%(trailers:key=Task-Status,valueonly)' \
-  --grep='Task-Status:' <branch>
-```
+  --grep='Task-Status:' loom/<agent>-<slug>
 
-#### Task assignment details
+# All findings from a completed agent
+git log --format='%(trailers:key=Key-Finding,valueonly)' loom/<agent>-<slug> \
+  | grep -v '^$'
 
-```bash
-git log -1 --format='%B' --grep='Task-Status: ASSIGNED' <branch>
-```
+# All decisions
+git log --format='%(trailers:key=Decision,valueonly)' loom/<agent>-<slug> \
+  | grep -v '^$'
 
-#### All state transitions for a session
+# Check if a dependency is met
+git log -1 --format='%(trailers:key=Task-Status,valueonly)' \
+  --grep='Task-Status:' loom/<dep-agent>-<dep-slug>
+# Result: "COMPLETED" means met
 
-```bash
-git log --format='%h %s | %(trailers:key=Task-Status,valueonly)' \
-  --grep='Session-Id: <session-id>' <branch>
-```
+# Last heartbeat
+git log -1 --format='%(trailers:key=Heartbeat,valueonly)' loom/<agent>-<slug>
 
-#### All key findings for a session
+# Full trailer dump for a branch
+git log --format='%H %s%n%(trailers)%n---' loom/<agent>-<slug>
 
-```bash
-git log --format='%(trailers:key=Key-Finding,valueonly)' \
-  --grep='Session-Id: <session-id>' <branch> | grep -v '^$'
-```
-
-#### All decisions for a session
-
-```bash
-git log --format='%(trailers:key=Decision,valueonly)' \
-  --grep='Session-Id: <session-id>' <branch> | grep -v '^$'
-```
-
-#### All deviations for a session
-
-```bash
-git log --format='%(trailers:key=Deviation,valueonly)' \
-  --grep='Session-Id: <session-id>' <branch> | grep -v '^$'
-```
-
-#### Files changed count from completion commit
-
-```bash
-git log -1 --format='%(trailers:key=Files-Changed,valueonly)' \
-  --grep='Task-Status: COMPLETED' <branch>
-```
-
-#### List all active agents (branches with IMPLEMENTING, no terminal state)
-
-```bash
-for branch in $(git branch -a --list 'loom/*' --format='%(refname:short)'); do
-  status=$(git log -1 --format='%(trailers:key=Task-Status,valueonly)' \
-    --grep='Task-Status:' "$branch")
-  if [ "$status" = "IMPLEMENTING" ]; then
-    agent=$(git log -1 --format='%(trailers:key=Agent-Id,valueonly)' \
-      --grep='Task-Status:' "$branch")
-    echo "$agent on $branch"
-  fi
+# Find all ASSIGNED branches (undispatched work)
+for b in $(git branch --list 'loom/*' --format='%(refname:short)'); do
+  s=$(git log -1 --format='%(trailers:key=Task-Status,valueonly)' \
+    --grep='Task-Status:' "$b" | head -1 | xargs)
+  [[ "$s" == "ASSIGNED" ]] && echo "$b"
 done
 ```
 
-### 8.7 Validation Rules
+---
 
-Orchestrators and CI systems MUST validate the following before integrating an agent's branch.
+## 8. Validation Rules
 
-#### Per-commit validation
+**Status: Not Yet Enforced.** These rules describe the target state for CI/validator tooling. They are normative requirements that will be checked once a validator exists. Until then, they serve as the compliance checklist for manual review.
+
+### 8.1 Per-commit validation
 
 1. Every commit MUST have `Agent-Id` and `Session-Id` trailers.
-2. `Agent-Id` MUST match `[a-z0-9]+(-[a-z0-9]+)*` (kebab-case). The orchestrator uses its own agent name (e.g., `bitswell`), not a special literal.
+2. `Agent-Id` MUST match `[a-z0-9]+(-[a-z0-9]+)*` (kebab-case).
 3. `Session-Id` MUST be a valid UUID v4.
 4. If `Task-Status` is present, its value MUST be one of: `ASSIGNED`, `IMPLEMENTING`, `COMPLETED`, `BLOCKED`, `FAILED`.
 5. Commits with `Task-Status: ASSIGNED` MUST also have `Assigned-To`, `Assignment`, `Scope`, `Dependencies`, and `Budget`.
 6. Commits with `Task-Status: COMPLETED` MUST also have `Files-Changed` (integer >= 0) and at least one `Key-Finding`.
 7. Commits with `Task-Status: BLOCKED` MUST also have `Blocked-Reason`.
-8. Commits with `Task-Status: FAILED` MUST also have `Error-Category` (valid enum value) and `Error-Retryable` (`true` or `false`).
+8. Commits with `Task-Status: FAILED` MUST also have `Error-Category` and `Error-Retryable`.
 
-#### Branch-level validation
+### 8.2 Branch-level validation
 
-9. The first commit on the branch MUST have `Task-Status: ASSIGNED` (from the orchestrator).
+9. The first commit on the branch MUST have `Task-Status: ASSIGNED` (from bitswell).
 10. The agent's first commit MUST have `Task-Status: IMPLEMENTING`.
 11. A branch MUST NOT have more than one `COMPLETED` or `FAILED` commit. These are terminal states.
-12. After a terminal state (`COMPLETED` or `FAILED`), no further commits with `Task-Status` are permitted.
-13. All commits on the branch MUST share the same `Session-Id`, except the `ASSIGNED` commit which carries bitswell's session ID.
+12. After a terminal state, no further commits with `Task-Status` are permitted. Orchestrator post-terminal commits use `chore(loom):` with no `Task-Status`.
+13. All agent commits on the branch MUST share the same `Session-Id`. The `ASSIGNED` commit carries bitswell's session ID.
 14. `BLOCKED` is non-terminal. An agent MAY transition from `BLOCKED` back to `IMPLEMENTING`.
 
-#### State machine
+### 8.3 State machine
 
 ```
 ASSIGNED --> IMPLEMENTING --> COMPLETED
@@ -602,8 +378,8 @@ Valid transitions:
 - `ASSIGNED` -> `IMPLEMENTING` (agent starts work)
 - `IMPLEMENTING` -> `COMPLETED` (agent finishes)
 - `IMPLEMENTING` -> `BLOCKED` (agent cannot proceed)
-- `IMPLEMENTING` -> `FAILED` (agent encountered unrecoverable error)
-- `BLOCKED` -> `IMPLEMENTING` (blocker resolved, agent resumes)
+- `IMPLEMENTING` -> `FAILED` (unrecoverable error)
+- `BLOCKED` -> `IMPLEMENTING` (blocker resolved)
 
 Invalid transitions (MUST reject):
 - Any state -> `ASSIGNED` (assignment happens once)
@@ -611,3 +387,7 @@ Invalid transitions (MUST reject):
 - `FAILED` -> any state (terminal)
 - `BLOCKED` -> `COMPLETED` (must resume `IMPLEMENTING` first)
 - `BLOCKED` -> `FAILED` (must resume `IMPLEMENTING` first)
+
+---
+
+*End of LOOM Schemas Reference v1.0.0-draft.*


### PR DESCRIPTION
## Summary

Consolidates all LOOM v2 deliverables (PRs #29-#32) with 10 fixes from glitch's e2e test (#33):

1. **PLANNING removed** from v2 state machine (was v1 two-phase only)
2. **Blocked-Reason** (not Blocked-By) — matches mcagent-spec naming
3. **Agent-Id: bitswell** for orchestrator — no special "orchestrator" literal
4. **Scope-Denied trailer** added — paths_denied now expressible in commits
5. **Multi-repo: .repos/ with submodules** — single-repo first, this repo is source of truth
6. **loom-spawn.sh created** — dispatch pipeline now complete (dispatch + spawn)
7. **Scope is "."** — agent owns its PWD (the worktree)
8. **Orchestrator identity** section added (Section 3.6)
9. **PWD convention** documented — dispatch cds into worktree before spawning
10. **Dependencies format** clarified: `<agent>/<assignment>` refs

### Files (5, 1494 insertions)
- `mcagent-spec.md` — v0.2.0, three-layer ontology + all fixes
- `protocol.md` — v1/v2 convention table in Section 4
- `schemas.md` — Section 8 commit-based protocol + all trailer fixes
- `loom-dispatch.sh` — 195 lines, detects ASSIGNED commits, spawns agents
- `loom-spawn.sh` — 36 lines, invokes Claude Code CLI from worktree PWD

### Agents involved
- **vesper** — designed .mcagent/ spec
- **ratchet** — defined commit schema + dispatch script
- **moss** — migrated identities
- **glitch** — found all the bugs
- **bitswell** — orchestrated, applied fixes

Created via LOOM v2 protocol.