### PR TITLE
RFP gh-stack: team-4 proposal (worker-side stacking with delegated authority)

### DIFF
--- a/docs/rfcs/gh-stack-integration/team-4/OUTLINE.md
+++ b/docs/rfcs/gh-stack-integration/team-4/OUTLINE.md
@@ -2,175 +2,140 @@
 
 ## Angle statement
 
-**Post-hoc projection: `gh-stack` adopts already-completed LOOM branches as a read-only reviewability lens; LOOM's DAG and `--no-ff` integration remain the sole source of truth.**
+**Worker-side stacking with delegated authority: for stack-epic assignments, LOOM explicitly delegates `gh stack` authority to workers, who init, add, rebase, and submit from inside their own worktrees, and the trust model shifts from "orchestrator owns all GitHub writes" to "orchestrator owns the audit contract, workers own the stack mechanics."**
 
-(27 words.)
+(Collision-detection key: *worker-authority stacking*, *delegated-stack stacking*, or *worker-driven stacking* — all three refer to the same angle. Explicitly NOT "post-hoc projection" — that is team 1's reassigned angle.)
 
 ## Thesis
 
-Every other plausible integration (new trailers, MCP wrappers, stack-mode
-integration, convention-only recipes) has to reconcile two models that pull in
-opposite directions: LOOM treats merges as audit facts and forbids worker PR
-authority, while `gh-stack` rebases, force-pushes, and assumes the branch
-author drives submission. This proposal refuses the reconciliation. LOOM runs
-to completion exactly as it does today — workers commit, orchestrator
-`--no-ff` merges onto `main` — and **only after** an epic's DAG has finished
-integrating, the orchestrator runs `gh stack init --adopt` against the same
-branches it just merged, purely to publish a stacked PR chain for human
-reviewers. The stack is a projection of history, not a mode of work. This
-angle is the right bet because it is the only one that leaves both systems
-unmodified in their hot paths: zero protocol changes, zero worker changes,
-zero merge-semantics changes, and the merge-vs-rebase incompatibility simply
-never arises because rebases happen on read-only branches after the merge is
-already a fact on `main`.
+Every other plausible integration leaves the worker out of the `gh stack` call path and pays a price for it: post-hoc projection (team 1) cannot react to live rebases, MCP wrappers force every stack op through an orchestrator round-trip, and convention-only recipes either give up on stacks mid-work or require the orchestrator to pretend it is the branch author. All of them fight the grain of `gh-stack`, which was designed on the assumption that *the person making the commits also drives the stack*. This proposal aligns with that grain: for stack-epic assignments, the worker is the branch author and the stack driver, full stop. The bet is that **proximity of data beats protocol purity**. Stack rebases, conflict recoveries, and mid-stack edits all need the exact working-tree state the worker already has — forcing those ops through an orchestrator means serializing on a process that has no working tree, no rerere cache, and no memory of the last conflict. Worker-side stacking reduces orchestrator round-trips from O(branches × rebases) to O(1) per epic, eliminates the "who force-pushed my stack" race, and puts ownership where the information lives. The cost is real: LOOM's scope and audit invariants must be *deliberately* relaxed for stack-epic workers, and a new trust tier must be introduced. This proposal is the only one that names that cost in the angle statement itself instead of hiding it behind projection tricks.
 
 ## Section headers for `proposal.md`
 
-The writer must fill in all seven RFP-required sections in the order below.
-Each header lists 2–5 bullet claims the writer must argue.
+The writer must fill in all seven RFP-required sections in the order below. Each header lists 2–5 bullet claims the writer must argue. **Section 5 is the core of this angle** and must be written first-draft in full before sections 1–4 and 6–7.
 
 ### 1. Angle statement
 
-- Restate the one-sentence angle verbatim: post-hoc projection; `gh-stack` is
-  a read-only reviewability lens over a completed LOOM epic.
-- Name the collision-detection key clearly: *projection stacking*, *post-hoc
-  adoption*, or *downstream-only stacking* — all three refer to the same
-  angle.
-- Contrast explicitly with angles the writer should assume other teams will
-  pick (new trailers, MCP wrappers, stack-mode integration, convention
-  recipes) and say why none of them share this bet.
+- Restate the one-sentence angle verbatim: worker-side stacking with delegated authority, orchestrator owns the audit contract, workers own stack mechanics.
+- Name the collision-detection key: *worker-authority stacking*. Explicitly disjoint from team 1's *post-hoc projection* and from any proposal that keeps workers on the orchestrator side of `gh stack`.
+- Frame the bet up front: *proximity of data beats protocol purity*. Commit to that tradeoff in one sentence — the writer must not soften it.
+- State the hard constraint the reviewer will check: any sentence in this proposal implying workers do not run `gh stack` commands is a bug, and must be rewritten.
 
 ### 2. What changes
 
-- **`loom-tools`**: add exactly one new tool, `stack-publish`, with
-  `roles: ['orchestrator']`, whose entire job is to run
-  `gh stack init --adopt` over a list of already-merged LOOM branches and
-  `gh stack submit --auto --draft` to open the PR chain. No new tool wraps
-  any worker-facing stack operation.
-- **Plugin/skill surface**: add a `publish-stack` recipe to the `loom` skill
-  that the orchestrator invokes after epic integration. No worker-template
-  change. No schema change.
-- **Schemas**: **zero changes**. No new trailers. No new `Task-Status`
-  values. The writer should quote `schemas.md §3` to prove this.
-- **File paths to touch** (writer lists them concretely): new
-  `repos/bitswell/loom-tools/src/tools/stack-publish.ts`, registration in
-  `repos/bitswell/loom-tools/src/tools/index.ts`, and a new recipe under
-  `/home/willem/.claude/plugins/cache/loom-plugin/loom/0.1.0/skills/loom/`
-  (writer confirms exact recipe-dir path).
-- **Non-goal to state explicitly**: neither `pr-create.ts` nor
-  `pr-retarget.ts` is modified; they continue to do single-PR work and are
-  the *only* PR surface during integration.
+- **`loom-tools`**: add new tool `stack-worker-init` with `roles: ['worker']` (a role value that does not yet exist — writer must propose adding it to the tool schema in `src/types/tool.ts`). This tool exposes a scoped subset of `gh stack` (init, add, rebase, submit, sync, view) to workers, running inside the worker's worktree. The existing `pr-create` and `pr-retarget` tools remain `roles: ['orchestrator']` and continue to own non-stack PR creation.
+- **Role enum expansion**: the writer must cite `repos/bitswell/loom-tools/src/tools/pr-create.ts` line 27 (`roles: ['orchestrator']`) and explain that today the role enum is effectively binary. This proposal adds a third role `worker-stack-driver` (or equivalent) that is a strict superset of `worker` for stack-epic assignments only.
+- **Plugin/skill surface**: extend the `loom` skill with a `stack-epic` recipe that (a) the orchestrator invokes during decomposition to mark an epic as stack-mode, and (b) the worker template loads additional instructions from when the assignment carries a `Stack-Epic: true` trailer.
+- **Worker template**: edit `/home/willem/.claude/plugins/cache/loom-plugin/loom/0.1.0/skills/loom/references/worker-template.md` to add a Section 10 — "Stack-epic workers" — that overrides Section 9 (scope enforcement) with the relaxed rules defined in section 5 of this proposal.
+- **Schemas**: add `Stack-Epic: <true|false>` and `Stack-Position: <integer>` trailers to `schemas.md §3.3` (assignment trailers). These are REQUIRED on ASSIGNED commits for stack-epic branches, FORBIDDEN on non-stack branches. Also add `Stack-Op: <init|add|rebase|submit|sync>` to §3.2 (state trailers) so worker stack ops are auditable in commit history.
+- **File paths to touch** (writer lists them concretely): new `repos/bitswell/loom-tools/src/tools/stack-worker-init.ts`, modifications to `repos/bitswell/loom-tools/src/types/tool.ts` (role enum), registration in `repos/bitswell/loom-tools/src/tools/index.ts`, amendment to `worker-template.md`, amendment to `schemas.md §3.3`, and a new recipe file under the loom skill directory.
 
 ### 3. Branch naming and scope
 
-- LOOM branches keep their canonical `loom/<agent>-<slug>` form through
-  integration. `gh-stack`'s prefix model is **never applied during work** —
-  only at adoption time, and even then only as a projection.
-- `gh stack init --adopt loom/<a>-<s1> loom/<b>-<s2> ...` is run without
-  `-p`, so adopted branches retain their names; `gh-stack` sees them as a
-  bare chain of existing refs, which the SKILL explicitly supports.
-- `Scope:` enforcement is **unchanged** because the stack is built only from
-  branches whose scopes LOOM has already validated at integration time; the
-  adoption step never reads or rewrites file paths.
-- The writer must address the edge case where a LOOM epic includes agents
-  whose branches have *already been force-deleted* post-merge and show how
-  `stack-publish` detects this and refuses the projection.
+- LOOM branches in a stack epic use a compound convention: `loom/<lead-agent>-<epic-slug>/<layer-slug>`. The lead agent is assigned the entire stack; each layer has its own slug. `gh-stack`'s `-p` prefix is set to `loom/<lead-agent>-<epic-slug>` and subsequent `gh stack add` calls pass only the layer suffix, matching the SKILL's prefix-handling rules.
+- One worker owns the whole stack (not one worker per layer). This is a deliberate departure from LOOM's "one agent per branch" rule and the writer must call it out. Rationale: `gh stack` ops require sequential access to the worktree and rerere cache; parallel workers on a shared stack would race on the stack file and trip exit code 8 (stack locked).
+- **`Scope:` enforcement across a stack is relaxed**: the assignment's `Scope:` trailer is a *union* across all intended layers, and the orchestrator verifies at integration time that every commit on every stack branch touches only files in the union scope. A per-branch scope trailer (`Scope-Layer: <layer>:<paths>`) is optional and advisory.
+- **Scope enforcement when workers touch branches beyond their own**: because the stack is owned by a single worker, "branches beyond their own" means branches the worker created via `gh stack add`. These are all in the worker's worktree, all under the same `loom/<lead-agent>-<epic-slug>/*` namespace, and all covered by the union scope. The orchestrator runs scope verification against the entire branch set at integration, not per-branch. The writer must show the verification pseudocode.
+- Edge case the writer must address: what happens if a stack-epic worker calls `gh stack rebase` on a layer whose scope it does not own. Answer: the rebase still happens (git allows it), but integration rejects any commit whose diff touches out-of-scope paths, so the worker gains nothing by cheating.
 
 ### 4. Merge vs rebase
 
-- The merge-vs-rebase tension **does not exist** in this angle: LOOM's
-  `--no-ff` merge onto `main` happens first, the audit trail is already a
-  fact, and only then does `gh-stack` rebase.
-- Rebases performed by `gh-stack` operate on the *adopted* refs, which at
-  that point are historical branch tips behind `main`. The writer must show
-  that force-pushes from `gh stack submit` touch only the adopted branches,
-  not `main`, and therefore cannot corrupt the audit log.
-- Risk to name: if a human later runs `gh stack rebase` on a published stack
-  after new commits have landed on `main`, the adopted branches get
-  retargeted in a way LOOM did not authorize. Mitigation: `stack-publish`
-  marks the stack with a label `loom-projection` and a repo-level guard hook
-  rejects further `gh stack` operations on labelled stacks.
-- Compare-and-contrast paragraph: show why a rebase-first angle must either
-  rewrite history on `main` or abandon `--no-ff`, and quote LOOM's audit
-  invariant to justify refusing that trade.
+- The writer must open section 4 with the direct statement: "This proposal breaks LOOM's `--no-ff` merge invariant for stack-epic branches, and here is why the trade is worth it."
+- `gh-stack` rebases and force-pushes by design. Workers run `gh stack rebase` and `gh stack submit` from inside the worktree, which means worker commits are rewritten and force-pushed over their own history before integration. LOOM's integration step cannot `--no-ff` merge branches whose history was rewritten after the ASSIGNED commit — the ASSIGNED commit is no longer a parent.
+- **Relaxation**: for stack-epic branches, LOOM's integration step (`protocol.md §3.3`) is replaced with a *cascading fast-forward merge*. The orchestrator merges the bottom of the stack into `main` with `--ff-only`, then the next layer into `main` with `--ff-only`, and so on. No merge commits. The audit trail is preserved via worker commit trailers (every stack op carries `Stack-Op:` and `Agent-Id`), not via `--no-ff` merge commits.
+- **Audit trail preservation**: the writer must show concretely how `git log --first-parent main` still reconstructs the full sequence of stack ops after integration. Every worker commit carries `Agent-Id`, `Session-Id`, and `Stack-Op`, so the audit trail is in the commit trailers rather than in merge-commit structure. The trailer-based audit is *stronger* than `--no-ff` structure because it survives rebases, which `--no-ff` does not.
+- **Relaxed invariant (named explicitly)**: LOOM's rule "integration uses `--no-ff` for audit trail" is relaxed to "integration uses `--ff-only` for stack-epic branches; audit trail lives in trailers, not merge commit structure." The writer must cite `protocol.md §3.3` and explicitly identify the clause being relaxed.
+- **Compare-and-contrast paragraph**: show that team 1's post-hoc projection preserves `--no-ff` by moving stacking *after* integration, paying the cost that workers cannot react to conflicts during work. This proposal makes the opposite bet: take the audit-structure hit to buy worker-driven conflict recovery. The writer must name this tradeoff in plain language.
 
-### 5. Worker authority
+### 5. Worker authority — THE CORE SECTION
 
-- Workers **never** invoke any `gh stack` command. The worker template,
-  `mcagent-spec.md`, and the `roles: ['orchestrator']` constraint on every
-  PR-related tool in `loom-tools` all remain in force unchanged.
-- The new `stack-publish` tool is gated with `roles: ['orchestrator']`
-  exactly as `pr-create` and `pr-retarget` already are — the writer should
-  cite the `roles` field in `pr-create.ts` line 26 and `pr-retarget.ts`
-  line 24 as precedent.
-- No LOOM invariant is relaxed. The writer must state this explicitly as a
-  *feature* of this angle, contrasting with any proposal that lets workers
-  run `gh stack` commands.
-- Spell out what happens if a worker accidentally runs `gh stack` anyway:
-  the command fails on the worktree's isolated ref layout, and even if it
-  succeeded it would be invisible to the orchestrator, which re-adopts
-  branches from scratch at publish time.
+This is the load-bearing section of this proposal. The writer must fill it out in full before any other section. Every other section is downstream of the trust-boundary rethink here.
+
+- **What workers gain the right to do** (enumerate exhaustively): `gh stack init`, `gh stack add`, `gh stack rebase` (all variants including `--continue` and `--abort`), `gh stack submit --auto --draft`, `gh stack sync`, `gh stack view --json`, `gh stack push`, `gh stack checkout` by branch name, `gh stack up/down/top/bottom`, `gh stack unstack`. Workers do NOT gain the right to run `gh pr create`, `gh pr merge`, `gh pr edit`, or any non-stack `gh` command. The grant is scoped to the `gh stack` subcommand tree.
+- **Which LOOM invariants are relaxed** (the writer MUST list these by name, quote the relevant section, and justify each):
+  1. **`protocol.md §6.1` "Workspace write — Only the orchestrator writes to the workspace. Agents MUST NOT."** — *Relaxed* for stack-epic workers: workers still do not write to the primary workspace, but they now force-push to remote refs under `loom/<lead-agent>-<epic-slug>/*`, which the orchestrator previously considered its exclusive write surface. Justification: force-pushes during stack rebase are mechanically required by `gh-stack` and cannot be serialized through the orchestrator without losing rerere state.
+  2. **`protocol.md §6.1` "Agent scope — An agent may modify only files matching its `Scope` trailer."** — *Relaxed to a union*: scope is enforced across the stack's union rather than per-branch. Section 3 of this proposal specifies the verification algorithm.
+  3. **`protocol.md §3.3` `integrate()` — the `--no-ff` merge step.** — *Replaced* with cascading `--ff-only` for stack-epic branches, as detailed in section 4.
+  4. **`pr-create.ts` `roles: ['orchestrator']` precedent.** — *Partially relaxed*: a new role tier is introduced (`worker-stack-driver`) that grants access to the `gh stack` subcommand tree only. The orchestrator-only guard remains in force for `pr-create`, `pr-retarget`, and every non-stack PR tool.
+  5. **`worker-template.md` §9 "Scope Enforcement — You MUST NOT modify files outside `scope.paths_allowed`."** — *Relaxed to union scope* per relaxation 2 above.
+  6. **`protocol.md §2` one-agent-per-branch rule (implicit in the state machine).** — *Relaxed*: one worker owns multiple branches (one per stack layer) under the same assignment. The ASSIGNED commit declares the stack via `Stack-Epic: true` and a list of layer slugs.
+- **How scope enforcement still works when workers touch branches beyond their own**: the writer must spell out the verification algorithm. Pseudocode:
+  ```
+  on integrate(stack-epic-assignment):
+    union_scope = assignment.scope  # already a union across layers
+    for branch in stack.branches:
+      for commit in branch.commits_since_assigned:
+        for path in commit.files_changed:
+          if path not in union_scope:
+            reject integration
+    verify branch topology matches Stack-Position trailers
+    verify Stack-Op trailers form a valid gh-stack sequence
+    cascading ff-only merge
+  ```
+  Scope enforcement is stricter in one sense (every commit on every branch is checked) and looser in another (checked against the union, not per-branch).
+- **How the audit trail is preserved**: every worker stack op emits a commit with `Stack-Op: <op>`, `Agent-Id`, `Session-Id`, and `Heartbeat`. The commit on each layer branch is the ground truth. `git log --all loom/<lead>-<epic>/*` reconstructs the full sequence of ops. The writer must show an example `git log` extraction that recovers the stack ops in order. The trailer-based audit is strictly *more* information than `--no-ff` merge structure provides today — merge commits tell you when branches landed, but not when they were rebased, conflict-recovered, or reordered mid-work.
+- **The new trust tier — `worker-stack-driver`**: introduce the concept explicitly. Workers assigned to stack-epic tasks run with elevated authority over the `gh stack` subcommand tree and over force-pushes within their epic's branch namespace. The orchestrator's ASSIGNED commit grants this by carrying `Stack-Epic: true`. Any worker receiving an assignment without that trailer remains on the old trust tier.
+- **The orchestrator's retained authority**: the orchestrator remains the sole party that (a) creates ASSIGNED commits, (b) decides whether an epic is a stack epic, (c) verifies scope at integration, (d) runs the cascading `--ff-only` integration, (e) opens non-stack PRs via `pr-create`, and (f) closes/merges PRs on GitHub. Workers cannot merge their own stacks to `main`; `gh stack submit --auto --draft` only creates draft PRs.
+- **Answer the question the feedback commit demanded**: *What happens to LOOM's trust model when we let workers drive stacking?* The trust model shifts from *mechanism control* (orchestrator owns every GitHub write) to *contract control* (orchestrator owns the scope contract, the integration contract, and the audit contract; workers own the mechanics within those contracts). The orchestrator stops being a bottleneck for mechanical operations and becomes a verifier of worker outputs. The writer must include this paragraph verbatim as the closing of section 5.
+- **Failure modes the writer must address**:
+  1. A worker force-pushes outside its stack namespace → integration scope check rejects the branch.
+  2. A worker runs `gh stack submit --auto` without `--draft` → the assignment spec forbids this; integration rejects the branch if non-draft PRs exist under the epic namespace.
+  3. A worker invokes `gh pr create` instead of `gh stack submit` → the MCP `stack-worker-init` tool does not expose `pr create`; a worker bypassing it via raw `gh` is caught by integration's "no PRs outside stack-worker-init sessions" check.
+  4. A worker gets compacted mid-rebase → `gh stack rebase --continue` is idempotent and recoverable from commit history; worker template section 10 prescribes the recovery procedure.
 
 ### 6. End-to-end example
 
-Trace the canonical `auth → api → frontend` three-agent epic. The writer
-must cover every numbered step in order:
+Trace the canonical `auth → api → frontend` three-agent epic. Because this proposal uses one worker per stack, the "three agents" become "one worker, three layers." The writer must cover every numbered step in order and include commit-message excerpts.
 
-- Epic decomposition: orchestrator creates three ASSIGNED commits on
-  `loom/ratchet-auth-middleware`, `loom/moss-api-endpoints`,
-  `loom/ratchet-frontend`, with `Dependencies:` wired `none`,
-  `ratchet/auth-middleware`, `moss/api-endpoints`.
-- Parallel-or-serial work phase: show `dag-check` producing the integration
-  order, workers committing IMPLEMENTING → COMPLETED with Heartbeats.
-- Integration phase: orchestrator does `--no-ff` merge of
-  `loom/ratchet-auth-middleware` into `main`, then `loom/moss-api-endpoints`,
-  then `loom/ratchet-frontend`. Standard LOOM. Show the three merge commits.
-- Publish phase: orchestrator invokes `stack-publish` with the integration
-  order. Under the hood: `gh stack init --adopt` over the three branches,
-  `gh stack submit --auto --draft` to create three draft PRs whose bases
-  chain `main` → auth → api → frontend.
-- Post-publish: human reviewer reads the three draft PRs top-down as a
-  coherent ladder; merging any PR is a no-op on `main` (already merged) and
-  the orchestrator closes the draft stack with a follow-up tool call.
+- **Epic decomposition**: orchestrator creates ONE ASSIGNED commit on branch `loom/ratchet-auth-stack` with body:
+  ```
+  task(ratchet): stack epic — auth → api → frontend
+
+  Agent-Id: bitswell
+  Session-Id: <uuid>
+  Task-Status: ASSIGNED
+  Assigned-To: ratchet
+  Assignment: auth-stack
+  Stack-Epic: true
+  Stack-Position: 1:auth-middleware,2:api-endpoints,3:frontend
+  Scope: src/auth/**, src/api/**, src/frontend/**, tests/**
+  Dependencies: none
+  Budget: 120000
+  ```
+  Only one branch is created at assignment time; the worker creates layer branches via `gh stack add`.
+- **Worker start**: ratchet commits `chore(loom): begin auth-stack` with `Task-Status: IMPLEMENTING` and `Stack-Op: init`. First real command is `gh stack init -p loom/ratchet-auth-stack auth-middleware` (note: the prefix embeds the loom namespace so `gh stack add api-endpoints` creates `loom/ratchet-auth-stack/api-endpoints`).
+- **Layer 1 — auth-middleware**: ratchet writes auth middleware code, `git commit` with `Stack-Op: commit`, `Agent-Id`, `Session-Id`, `Heartbeat`. Multiple commits allowed per layer.
+- **Layer 2 — api-endpoints**: `gh stack add api-endpoints` — worker commits `chore(loom): stack add api-endpoints` with `Stack-Op: add`. Writes API code, more commits.
+- **Mid-stack edit**: worker realises auth middleware needs a helper function. `gh stack down`, edit, commit, `gh stack rebase --upstack`, `gh stack top`. Each op is a commit with `Stack-Op:` trailer. Writer must show the commit graph at this point.
+- **Layer 3 — frontend**: `gh stack add frontend`, write frontend code, commits.
+- **Conflict recovery**: show one conflict during `gh stack rebase --upstack`, worker resolves, `git add`, `gh stack rebase --continue`. Commit trailer: `Stack-Op: rebase-continue`.
+- **Submit**: `gh stack submit --auto --draft` — worker commits `feat(auth-stack): submit draft stack` with `Task-Status: COMPLETED`, `Files-Changed`, `Key-Finding: three draft PRs created`, `Stack-Op: submit`, and the PR numbers in the body. Note: this is a non-trivial relaxation — the worker is creating PRs, even if drafts.
+- **Integration phase**: orchestrator runs scope verification (union scope across all three branches), verifies `Stack-Op:` sequence is valid, verifies draft-only flag, then cascading `--ff-only` merge: `git merge --ff-only loom/ratchet-auth-stack/auth-middleware` → `loom/ratchet-auth-stack/api-endpoints` → `loom/ratchet-auth-stack/frontend`. Draft PRs on GitHub are marked ready and auto-merged, or closed in favour of the direct fast-forward (writer picks one and justifies).
+- **Audit recovery**: show the `git log --format='%H %s %(trailers:key=Stack-Op)' main` output that reconstructs the full worker stack-op sequence post-integration.
 
 ### 7. Risks and rejected alternatives
 
-- **Risk 1 — reviewer confusion**: stacked PRs that appear after their
-  commits already landed may confuse reviewers used to pre-merge review.
-  Mitigation: draft-only, labelled `loom-projection`, PR body explicitly
-  names them "historical review ladders."
-- **Risk 2 — branch-lifetime coupling**: the projection requires LOOM
-  branches to still exist at publish time; orchestrator's existing
-  post-merge branch cleanup must be deferred until after `stack-publish`.
-  Writer must name the exact cleanup step in LOOM that has to move.
-- **Risk 3 — stack drift if `main` advances**: if new commits land on `main`
-  between the last `--no-ff` merge and `stack-publish`, adoption still
-  works but the adopted branches are slightly behind. Writer must show the
-  one-line fix (adopt from the merge commits, not the branch tips).
-- **Rejected alternative A — live stacking during work**: require workers
-  to run `gh stack add` as they go. Rejected because it forces worker PR
-  authority and contradicts `roles: ['orchestrator']` precedent across
-  `loom-tools`.
-- **Rejected alternative B — protocol-level `Stack-Position` trailer**: add
-  a new trailer that declares stack order at assignment time. Rejected
-  because `Dependencies:` already encodes the chain and `dag-check.ts`
-  already computes the topological order; adding a parallel mechanism
-  violates the RFP's reusability criterion.
-- **Rejected alternative C — replace merge with rebase entirely**: abandon
-  `--no-ff` merges and switch LOOM to rebase-only integration so stacks
-  are native. Rejected because it destroys the audit trail LOOM's protocol
-  document names as a core invariant.
+- **Risk 1 — worker misbehaves with elevated authority**: a stack-epic worker could in principle force-push garbage over its stack. Mitigation: integration-time scope verification against union scope, Stack-Op sequence validation, and mandatory draft-only submission. The attack surface is bounded to the worker's own stack namespace.
+- **Risk 2 — audit trail depends on trailer discipline**: if a worker forgets `Stack-Op:` trailers, the audit reconstruction loses fidelity. Mitigation: `stack-worker-init` tool auto-stamps `Stack-Op:` trailers on every op; workers cannot run `gh stack` except through the tool.
+- **Risk 3 — one-worker-per-stack ceiling on parallelism**: because the stack is serial by construction, a stack epic cannot be split across parallel workers. Mitigation: this is a property of `gh-stack` itself (strictly linear stacks), not of this proposal; parallel epics use separate stacks.
+- **Risk 4 — relaxing `--no-ff` weakens the audit invariant for stack-epic branches**: named explicitly, justified by the trailer-based audit being strictly more informative. The writer must call this a *deliberate trade*, not a concession.
+- **Rejected alternative A — post-hoc projection (team 1's angle)**: orchestrator adopts branches after integration. Rejected because it requires workers to coordinate mid-work without stack tools, losing the exact benefit this proposal buys: worker-driven conflict recovery.
+- **Rejected alternative B — orchestrator-only `gh stack` via MCP wrapper**: every stack op is a round-trip through the orchestrator. Rejected because it serializes conflict recovery through a process with no working tree and no rerere cache, and because orchestrator context compaction would lose mid-rebase state.
+- **Rejected alternative C — keep orchestrator-only but pre-create all stack branches upfront**: orchestrator runs `gh stack init` before workers start, workers commit but never rebase. Rejected because it cannot handle mid-stack edits or conflict recovery — both of which require someone on the worktree with `gh stack` authority.
+- **Rejected alternative D — full `gh` grant to all workers (not just stack-epic)**: simpler role model, but massively wider blast radius. Rejected because non-stack assignments have no need for `gh`, and widening the grant unnecessarily violates least-privilege.
 
 ## Key references
 
-The writer must read these files before writing `proposal.md`. Paths are
-absolute unless noted.
+The writer must read these files before writing `proposal.md`. Paths are absolute unless noted.
 
-- **Epic RFP (authoritative requirements)**: `gh issue view 74 --repo bitswell/bitswell` — the seven required sections and five sharp edges are quoted from here.
-- **`gh-stack` SKILL**: `/home/willem/.agents/skills/gh-stack/SKILL.md` — read the "Agent rules" section for non-interactive flag requirements, the "Workflows → End-to-end" section for `init --adopt` semantics, and the "Quick reference" table for `gh stack init --adopt branch-a branch-b` syntax used by `stack-publish`.
-- **LOOM protocol**: `/home/willem/.claude/plugins/cache/loom-plugin/loom/0.1.0/skills/loom/references/protocol.md` — §2 state machine (IMPLEMENTING → COMPLETED), §3.3 `integrate()` (the `--no-ff` merge step this proposal leaves untouched), §4.2 dispatch.
-- **LOOM schemas**: `/home/willem/.claude/plugins/cache/loom-plugin/loom/0.1.0/skills/loom/references/schemas.md` — §3 trailer vocabulary (cite to prove zero additions), §3.3 `Dependencies` trailer (the DAG this proposal reuses), §2 branch-naming pattern (`loom/<agent>-<slug>`).
-- **`pr-create.ts`**: `/home/willem/bitswell/bitswell/repos/bitswell/loom-tools/src/tools/pr-create.ts` — line ~26, `roles: ['orchestrator']` is the precedent `stack-publish` must follow; the whole file is the template for the new tool.
-- **`pr-retarget.ts`**: `/home/willem/bitswell/bitswell/repos/bitswell/loom-tools/src/tools/pr-retarget.ts` — line ~24, same `roles: ['orchestrator']` guard; shows how the existing tool already supports arbitrary base branches and therefore needs no modification.
-- **`dag-check.ts`**: `/home/willem/bitswell/bitswell/repos/bitswell/loom-tools/src/tools/dag-check.ts` — the Kahn's-algorithm topological sort whose `integrationOrder` output this proposal reuses as the stack order at publish time.
-- **Tool registration**: `repos/bitswell/loom-tools/src/tools/index.ts` (writer confirms exact path) — where `stack-publish` must be registered alongside the existing PR tools.
+- **Feedback commit (rejection reason)**: `git log -1 --format='%B' HEAD` on this branch — read before writing; the first-draft outline's angle was reassigned away from post-hoc projection precisely because all five teams converged on it. This outline is the replacement.
+- **Epic RFP (authoritative requirements)**: `gh issue view 74 --repo bitswell/bitswell` — the seven required sections are quoted from here, and sharp edge 5 ("Worker-vs-orchestrator PR authority") is the exact question this proposal answers in the opposite direction from every other team.
+- **`gh-stack` SKILL**: `/home/willem/.agents/skills/gh-stack/SKILL.md` — read the "Agent rules" section (all ops non-interactive), "Workflows → Making mid-stack changes" (the exact pattern a worker runs during a stack edit), "Workflows → Handle rebase conflicts" (the recovery procedure the worker template section 10 must reference), and exit code 8 ("Stack is locked") which is the reason one worker owns the whole stack rather than one worker per layer.
+- **LOOM protocol**: `/home/willem/.claude/plugins/cache/loom-plugin/loom/0.1.0/skills/loom/references/protocol.md` — §2 state machine (one-agent-per-branch rule is relaxed), §3.3 `integrate()` (the `--no-ff` merge step is replaced with cascading `--ff-only` for stack-epic branches), §6.1 security model (workspace write, agent scope, and cross-agent isolation rules are all explicitly relaxed in this proposal and must be quoted).
+- **LOOM schemas**: `/home/willem/.claude/plugins/cache/loom-plugin/loom/0.1.0/skills/loom/references/schemas.md` — §3.3 assignment trailers (proposal adds `Stack-Epic` and `Stack-Position`), §3.2 state trailers (proposal adds `Stack-Op`), §4.1 required trailers per state (writer must show the extended required-trailer table for stack-epic ASSIGNED commits).
+- **LOOM worker template**: `/home/willem/.claude/plugins/cache/loom-plugin/loom/0.1.0/skills/loom/references/worker-template.md` — §9 scope enforcement (relaxed to union), §4 the work loop (workers now run `gh stack` ops here), proposed new §10 "Stack-epic workers" that the proposal must draft.
+- **`pr-create.ts`**: `/home/willem/bitswell/bitswell/repos/bitswell/loom-tools/src/tools/pr-create.ts` — line 27, `roles: ['orchestrator']` is the precedent this proposal partially relaxes by introducing a new role tier. The file is the template for the new `stack-worker-init` tool except for the `roles` value.
+- **`pr-retarget.ts`**: `/home/willem/bitswell/bitswell/repos/bitswell/loom-tools/src/tools/pr-retarget.ts` — line ~24, same `roles: ['orchestrator']` guard remains in force; the writer must state that `pr-retarget` is NOT modified because stack bases are set by `gh stack submit`, not `pr-retarget`.
+- **`dag-check.ts`**: `/home/willem/bitswell/bitswell/repos/bitswell/loom-tools/src/tools/dag-check.ts` — the topological sort still runs, but for stack epics it operates on a single assignment with layer positions rather than on multiple assignments. Writer must explain this reuse with one code snippet.
+- **Tool registration**: `repos/bitswell/loom-tools/src/tools/index.ts` (writer confirms exact path) — where `stack-worker-init` must be registered, and where the role enum lives.
+- **Tool types**: `repos/bitswell/loom-tools/src/types/tool.ts` (writer confirms exact path) — the `roles` field's enum definition is the file that must be amended to add the new `worker-stack-driver` role.

--- a/docs/rfcs/gh-stack-integration/team-4/OUTLINE.md
+++ b/docs/rfcs/gh-stack-integration/team-4/OUTLINE.md
@@ -1,0 +1,176 @@
+# Team 4 — OUTLINE
+
+## Angle statement
+
+**Post-hoc projection: `gh-stack` adopts already-completed LOOM branches as a read-only reviewability lens; LOOM's DAG and `--no-ff` integration remain the sole source of truth.**
+
+(27 words.)
+
+## Thesis
+
+Every other plausible integration (new trailers, MCP wrappers, stack-mode
+integration, convention-only recipes) has to reconcile two models that pull in
+opposite directions: LOOM treats merges as audit facts and forbids worker PR
+authority, while `gh-stack` rebases, force-pushes, and assumes the branch
+author drives submission. This proposal refuses the reconciliation. LOOM runs
+to completion exactly as it does today — workers commit, orchestrator
+`--no-ff` merges onto `main` — and **only after** an epic's DAG has finished
+integrating, the orchestrator runs `gh stack init --adopt` against the same
+branches it just merged, purely to publish a stacked PR chain for human
+reviewers. The stack is a projection of history, not a mode of work. This
+angle is the right bet because it is the only one that leaves both systems
+unmodified in their hot paths: zero protocol changes, zero worker changes,
+zero merge-semantics changes, and the merge-vs-rebase incompatibility simply
+never arises because rebases happen on read-only branches after the merge is
+already a fact on `main`.
+
+## Section headers for `proposal.md`
+
+The writer must fill in all seven RFP-required sections in the order below.
+Each header lists 2–5 bullet claims the writer must argue.
+
+### 1. Angle statement
+
+- Restate the one-sentence angle verbatim: post-hoc projection; `gh-stack` is
+  a read-only reviewability lens over a completed LOOM epic.
+- Name the collision-detection key clearly: *projection stacking*, *post-hoc
+  adoption*, or *downstream-only stacking* — all three refer to the same
+  angle.
+- Contrast explicitly with angles the writer should assume other teams will
+  pick (new trailers, MCP wrappers, stack-mode integration, convention
+  recipes) and say why none of them share this bet.
+
+### 2. What changes
+
+- **`loom-tools`**: add exactly one new tool, `stack-publish`, with
+  `roles: ['orchestrator']`, whose entire job is to run
+  `gh stack init --adopt` over a list of already-merged LOOM branches and
+  `gh stack submit --auto --draft` to open the PR chain. No new tool wraps
+  any worker-facing stack operation.
+- **Plugin/skill surface**: add a `publish-stack` recipe to the `loom` skill
+  that the orchestrator invokes after epic integration. No worker-template
+  change. No schema change.
+- **Schemas**: **zero changes**. No new trailers. No new `Task-Status`
+  values. The writer should quote `schemas.md §3` to prove this.
+- **File paths to touch** (writer lists them concretely): new
+  `repos/bitswell/loom-tools/src/tools/stack-publish.ts`, registration in
+  `repos/bitswell/loom-tools/src/tools/index.ts`, and a new recipe under
+  `/home/willem/.claude/plugins/cache/loom-plugin/loom/0.1.0/skills/loom/`
+  (writer confirms exact recipe-dir path).
+- **Non-goal to state explicitly**: neither `pr-create.ts` nor
+  `pr-retarget.ts` is modified; they continue to do single-PR work and are
+  the *only* PR surface during integration.
+
+### 3. Branch naming and scope
+
+- LOOM branches keep their canonical `loom/<agent>-<slug>` form through
+  integration. `gh-stack`'s prefix model is **never applied during work** —
+  only at adoption time, and even then only as a projection.
+- `gh stack init --adopt loom/<a>-<s1> loom/<b>-<s2> ...` is run without
+  `-p`, so adopted branches retain their names; `gh-stack` sees them as a
+  bare chain of existing refs, which the SKILL explicitly supports.
+- `Scope:` enforcement is **unchanged** because the stack is built only from
+  branches whose scopes LOOM has already validated at integration time; the
+  adoption step never reads or rewrites file paths.
+- The writer must address the edge case where a LOOM epic includes agents
+  whose branches have *already been force-deleted* post-merge and show how
+  `stack-publish` detects this and refuses the projection.
+
+### 4. Merge vs rebase
+
+- The merge-vs-rebase tension **does not exist** in this angle: LOOM's
+  `--no-ff` merge onto `main` happens first, the audit trail is already a
+  fact, and only then does `gh-stack` rebase.
+- Rebases performed by `gh-stack` operate on the *adopted* refs, which at
+  that point are historical branch tips behind `main`. The writer must show
+  that force-pushes from `gh stack submit` touch only the adopted branches,
+  not `main`, and therefore cannot corrupt the audit log.
+- Risk to name: if a human later runs `gh stack rebase` on a published stack
+  after new commits have landed on `main`, the adopted branches get
+  retargeted in a way LOOM did not authorize. Mitigation: `stack-publish`
+  marks the stack with a label `loom-projection` and a repo-level guard hook
+  rejects further `gh stack` operations on labelled stacks.
+- Compare-and-contrast paragraph: show why a rebase-first angle must either
+  rewrite history on `main` or abandon `--no-ff`, and quote LOOM's audit
+  invariant to justify refusing that trade.
+
+### 5. Worker authority
+
+- Workers **never** invoke any `gh stack` command. The worker template,
+  `mcagent-spec.md`, and the `roles: ['orchestrator']` constraint on every
+  PR-related tool in `loom-tools` all remain in force unchanged.
+- The new `stack-publish` tool is gated with `roles: ['orchestrator']`
+  exactly as `pr-create` and `pr-retarget` already are — the writer should
+  cite the `roles` field in `pr-create.ts` line 26 and `pr-retarget.ts`
+  line 24 as precedent.
+- No LOOM invariant is relaxed. The writer must state this explicitly as a
+  *feature* of this angle, contrasting with any proposal that lets workers
+  run `gh stack` commands.
+- Spell out what happens if a worker accidentally runs `gh stack` anyway:
+  the command fails on the worktree's isolated ref layout, and even if it
+  succeeded it would be invisible to the orchestrator, which re-adopts
+  branches from scratch at publish time.
+
+### 6. End-to-end example
+
+Trace the canonical `auth → api → frontend` three-agent epic. The writer
+must cover every numbered step in order:
+
+- Epic decomposition: orchestrator creates three ASSIGNED commits on
+  `loom/ratchet-auth-middleware`, `loom/moss-api-endpoints`,
+  `loom/ratchet-frontend`, with `Dependencies:` wired `none`,
+  `ratchet/auth-middleware`, `moss/api-endpoints`.
+- Parallel-or-serial work phase: show `dag-check` producing the integration
+  order, workers committing IMPLEMENTING → COMPLETED with Heartbeats.
+- Integration phase: orchestrator does `--no-ff` merge of
+  `loom/ratchet-auth-middleware` into `main`, then `loom/moss-api-endpoints`,
+  then `loom/ratchet-frontend`. Standard LOOM. Show the three merge commits.
+- Publish phase: orchestrator invokes `stack-publish` with the integration
+  order. Under the hood: `gh stack init --adopt` over the three branches,
+  `gh stack submit --auto --draft` to create three draft PRs whose bases
+  chain `main` → auth → api → frontend.
+- Post-publish: human reviewer reads the three draft PRs top-down as a
+  coherent ladder; merging any PR is a no-op on `main` (already merged) and
+  the orchestrator closes the draft stack with a follow-up tool call.
+
+### 7. Risks and rejected alternatives
+
+- **Risk 1 — reviewer confusion**: stacked PRs that appear after their
+  commits already landed may confuse reviewers used to pre-merge review.
+  Mitigation: draft-only, labelled `loom-projection`, PR body explicitly
+  names them "historical review ladders."
+- **Risk 2 — branch-lifetime coupling**: the projection requires LOOM
+  branches to still exist at publish time; orchestrator's existing
+  post-merge branch cleanup must be deferred until after `stack-publish`.
+  Writer must name the exact cleanup step in LOOM that has to move.
+- **Risk 3 — stack drift if `main` advances**: if new commits land on `main`
+  between the last `--no-ff` merge and `stack-publish`, adoption still
+  works but the adopted branches are slightly behind. Writer must show the
+  one-line fix (adopt from the merge commits, not the branch tips).
+- **Rejected alternative A — live stacking during work**: require workers
+  to run `gh stack add` as they go. Rejected because it forces worker PR
+  authority and contradicts `roles: ['orchestrator']` precedent across
+  `loom-tools`.
+- **Rejected alternative B — protocol-level `Stack-Position` trailer**: add
+  a new trailer that declares stack order at assignment time. Rejected
+  because `Dependencies:` already encodes the chain and `dag-check.ts`
+  already computes the topological order; adding a parallel mechanism
+  violates the RFP's reusability criterion.
+- **Rejected alternative C — replace merge with rebase entirely**: abandon
+  `--no-ff` merges and switch LOOM to rebase-only integration so stacks
+  are native. Rejected because it destroys the audit trail LOOM's protocol
+  document names as a core invariant.
+
+## Key references
+
+The writer must read these files before writing `proposal.md`. Paths are
+absolute unless noted.
+
+- **Epic RFP (authoritative requirements)**: `gh issue view 74 --repo bitswell/bitswell` — the seven required sections and five sharp edges are quoted from here.
+- **`gh-stack` SKILL**: `/home/willem/.agents/skills/gh-stack/SKILL.md` — read the "Agent rules" section for non-interactive flag requirements, the "Workflows → End-to-end" section for `init --adopt` semantics, and the "Quick reference" table for `gh stack init --adopt branch-a branch-b` syntax used by `stack-publish`.
+- **LOOM protocol**: `/home/willem/.claude/plugins/cache/loom-plugin/loom/0.1.0/skills/loom/references/protocol.md` — §2 state machine (IMPLEMENTING → COMPLETED), §3.3 `integrate()` (the `--no-ff` merge step this proposal leaves untouched), §4.2 dispatch.
+- **LOOM schemas**: `/home/willem/.claude/plugins/cache/loom-plugin/loom/0.1.0/skills/loom/references/schemas.md` — §3 trailer vocabulary (cite to prove zero additions), §3.3 `Dependencies` trailer (the DAG this proposal reuses), §2 branch-naming pattern (`loom/<agent>-<slug>`).
+- **`pr-create.ts`**: `/home/willem/bitswell/bitswell/repos/bitswell/loom-tools/src/tools/pr-create.ts` — line ~26, `roles: ['orchestrator']` is the precedent `stack-publish` must follow; the whole file is the template for the new tool.
+- **`pr-retarget.ts`**: `/home/willem/bitswell/bitswell/repos/bitswell/loom-tools/src/tools/pr-retarget.ts` — line ~24, same `roles: ['orchestrator']` guard; shows how the existing tool already supports arbitrary base branches and therefore needs no modification.
+- **`dag-check.ts`**: `/home/willem/bitswell/bitswell/repos/bitswell/loom-tools/src/tools/dag-check.ts` — the Kahn's-algorithm topological sort whose `integrationOrder` output this proposal reuses as the stack order at publish time.
+- **Tool registration**: `repos/bitswell/loom-tools/src/tools/index.ts` (writer confirms exact path) — where `stack-publish` must be registered alongside the existing PR tools.

--- a/docs/rfcs/gh-stack-integration/team-4/proposal.md
+++ b/docs/rfcs/gh-stack-integration/team-4/proposal.md
@@ -69,25 +69,43 @@ This section enumerates every component that changes, every file path that is to
 
 ### 3.2 Role enum expansion
 
-**File:** `repos/bitswell/loom-tools/src/types/tool.ts`
+**File:** `repos/bitswell/loom-tools/src/types/role.ts` (the role enum lives here; `src/types/tool.ts` only imports `ProtocolRole` from `./role.js` and uses it as the type of the `roles: readonly ProtocolRole[]` field on `ToolDefinition`).
 
-**Current state:** `roles` is effectively binary — tools are either `['orchestrator']` (see `pr-create.ts` line 27) or unrestricted. The type definition that gates this is the `roles` field on the `ToolDefinition` interface.
+**Current state:** `ProtocolRole` is a three-value union — `'writer' | 'reviewer' | 'orchestrator'`. Tools are either scoped to a specific role (e.g. `['orchestrator']`, see `pr-create.ts` line 27) or unrestricted. LOOM calls workers *writers* in the role enum; the proposal uses "worker" in prose but the enum value is `writer`.
 
-**Change:** add a third role value, `worker-stack-driver`, as a strict superset of `worker` for stack-epic assignments only.
+**Change:** add a new role value, `worker-stack-driver`, to `ProtocolRole` as a strict superset of `writer` for stack-epic assignments only. The `canAccess` helper in `role.ts` is extended so that `worker-stack-driver` is granted all tools gated on `writer` plus tools gated explicitly on `worker-stack-driver`.
 
 ```ts
-// repos/bitswell/loom-tools/src/types/tool.ts (amended)
-export type Role = 'orchestrator' | 'worker' | 'worker-stack-driver';
-export interface ToolDefinition<I, O> {
-  name: string;
-  description: string;
-  inputSchema: z.ZodType<I>;
-  outputSchema: z.ZodType<O>;
-  roles: Role[];
+// repos/bitswell/loom-tools/src/types/role.ts (amended)
+export type ProtocolRole =
+  | 'writer'
+  | 'reviewer'
+  | 'orchestrator'
+  | 'worker-stack-driver';
+
+export const PROTOCOL_ROLES: readonly ProtocolRole[] = [
+  'writer',
+  'reviewer',
+  'orchestrator',
+  'worker-stack-driver',
+] as const;
+
+export function canAccess(
+  agentRole: ProtocolRole,
+  toolRoles: readonly ProtocolRole[],
+): boolean {
+  if (agentRole === 'orchestrator') return true;
+  if (agentRole === 'worker-stack-driver') {
+    // stack-driver inherits writer access plus its own scoped tools
+    return toolRoles.includes('writer') || toolRoles.includes('worker-stack-driver');
+  }
+  return toolRoles.includes(agentRole);
 }
 ```
 
-**Enforcement:** the MCP dispatch layer already checks `roles` on every tool call and rejects unauthorised callers. The new role value is checked the same way. A worker running without `Stack-Epic: true` cannot successfully call `stack-worker-init` because the handler refuses and because the dispatch guard blocks the `worker-stack-driver` role from being asserted on non-stack-epic sessions.
+`src/types/tool.ts` does not need to change — its `roles: readonly ProtocolRole[]` field picks up the new value automatically because it imports from `./role.js`.
+
+**Enforcement:** the MCP dispatch layer already checks `roles` on every tool call and rejects unauthorised callers. The new role value is checked the same way. A writer running without `Stack-Epic: true` cannot successfully call `stack-worker-init` because the handler refuses and because the dispatch guard blocks the `worker-stack-driver` role from being asserted on non-stack-epic sessions.
 
 ### 3.3 Plugin / loom skill surface
 

--- a/docs/rfcs/gh-stack-integration/team-4/proposal.md
+++ b/docs/rfcs/gh-stack-integration/team-4/proposal.md
@@ -1,0 +1,980 @@
+# Team 4 — Proposal: Worker-side stacking with delegated authority
+
+**Epic:** [#74 — gh-stack integration](https://github.com/bitswell/bitswell/issues/74)
+**Team angle key:** *worker-authority stacking* (a.k.a. *delegated-stack stacking*, *worker-driven stacking*)
+**Explicit non-angle:** this proposal is **not** post-hoc projection. Post-hoc projection is team 1's reassigned angle and any sentence in this document implying workers only drive stacking after integration is a drafting bug.
+
+---
+
+## 1. Angle statement
+
+**Worker-side stacking with delegated authority: for stack-epic assignments, LOOM explicitly delegates `gh stack` authority to workers, who `init`, `add`, `rebase`, and `submit` from inside their own worktrees, and the trust model shifts from "orchestrator owns all GitHub writes" to "orchestrator owns the audit contract, workers own the stack mechanics."**
+
+That sentence is the contract. To make it impossible to misread, this proposal repeats the claim three times in different registers:
+
+- **In one sentence, mechanically:** When an assignment carries `Stack-Epic: true`, the worker runs `gh stack init`, `gh stack add`, `gh stack rebase`, `gh stack submit`, `gh stack sync`, `gh stack push`, `gh stack view --json`, and every `gh stack` navigation command directly from its worktree. The orchestrator does not run any `gh stack` command for that epic.
+- **In one sentence, architecturally:** The trust boundary between orchestrator and worker is redrawn so that the orchestrator retains exclusive authority over the *contract* (assignments, scope, integration, audit) while workers gain exclusive authority over the *mechanics* of stacking within their own epic's branch namespace.
+- **In one sentence, reductively:** *Proximity of data beats protocol purity.* `gh stack` was built on the assumption that the person making the commits also drives the stack. This proposal aligns LOOM with that assumption instead of fighting it.
+
+The collision-detection key is **worker-authority stacking**. This angle is disjoint from team 1's post-hoc projection (stack is assembled after integration), from any proposal that keeps workers on the orchestrator side of `gh stack`, and from any proposal that tries to satisfy the epic by adding an MCP wrapper tool with `roles: ['orchestrator']`. If the winning proposal does not let workers run `gh stack` commands, it is not this proposal.
+
+**The bet, stated as a tradeoff the reviewer must accept or reject:** Worker-driven conflict recovery and mid-stack edits are worth a deliberate, documented relaxation of LOOM's workspace-write and `--no-ff` audit invariants. This proposal does not try to soften the tradeoff. If the reviewer believes that no GitHub write should ever leave the orchestrator, this proposal is the wrong bet and team 1 is the right one.
+
+---
+
+## 2. Thesis
+
+Every other plausible integration path leaves the worker out of the `gh stack` call path and pays a price for it:
+
+- **Post-hoc projection** (team 1) produces a single pile of commits from the worker and projects a stack onto them after the fact. That works for clean linear work but cannot react to *live* conflicts: a worker that needs to revise layer 1 while working on layer 3 has no stack tools to navigate down, edit, and rebase upstack. The projection only exists in the orchestrator's head until integration time, which is exactly when conflict recovery has already been lost.
+- **Orchestrator-only MCP wrapper** (the obvious path, rejected alternative B below) forces every stack operation to round-trip through the orchestrator. That serializes conflict recovery on a process with no working tree and no `rerere` cache, and it means orchestrator context compaction silently destroys mid-rebase state.
+- **Convention-only recipes** that tell workers "don't stack, just commit, and the orchestrator will handle stacks later" are just post-hoc projection with worse ergonomics. They also require the orchestrator to pretend to be the branch author at submit time, which confuses `gh-stack`'s audit output.
+- **Pre-create every stack branch upfront** (rejected alternative C) tries to make stacks declarative so the orchestrator can stamp branches and workers can just commit to them. That works until the first mid-stack edit, at which point it collapses into one of the above.
+
+All four fight the grain of `gh-stack`. The skill at `/home/willem/.agents/skills/gh-stack/SKILL.md` is explicit on this point: agent rule 9 reads *"Navigate down the stack when you need to change a lower layer."* That instruction is written to the agent-that-has-the-worktree, not to a remote coordinator. `gh stack` exit code 8 (*"Stack is locked"*) is produced by a worktree-level lock file that cannot be safely shared across processes. The `git rerere` cache that powers smooth rebases lives inside `.git/rr-cache` of the worktree doing the rebase — not the orchestrator's worktree, and not any shared location. Every one of these facts says the same thing: **the party that makes the commits must also drive the stack.**
+
+This proposal accepts that message and reorganises LOOM's trust model around it. For stack-epic assignments, the worker is both the branch author *and* the stack driver, full stop. The orchestrator retreats from being a gatekeeper of mechanism and becomes a verifier of contract. It still owns ASSIGNED commits, scope verification, integration, and the audit reconstruction — but it no longer serializes on every force-push, every `rerere` lookup, every mid-rebase decision.
+
+The cost is real and named in the angle statement itself. LOOM's `protocol.md §6.1` "Workspace write" invariant must be deliberately relaxed for stack-epic workers. LOOM's `protocol.md §3.3` `--no-ff` integration step must be replaced with cascading `--ff-only` for stack-epic branches. LOOM's worker template `§9` scope enforcement must be relaxed to a union-scope model. And a new role tier — `worker-stack-driver` — must be introduced into `repos/bitswell/loom-tools/src/types/tool.ts` so that the tool schema can express "this tool is callable by a worker only when the assignment carries `Stack-Epic: true`."
+
+This proposal is the only one of the five that names that cost in its angle sentence. Every other team hides the cost behind a projection trick or an MCP wrapper. The reviewer should read this proposal as the one that tells the truth about what a real `gh-stack` integration costs LOOM, and then asks: given the cost, is worker-driven conflict recovery worth paying? The thesis is that it is, because conflict recovery and mid-stack edits are exactly the operations that make stacked diffs valuable in the first place. A stack that can only be built from green-path clean commits is not a stack — it is a linear diff with extra ceremony. A stack that workers can edit, rebase, and recover under pressure is the thing that justifies the tooling.
+
+---
+
+## 3. What changes
+
+This section enumerates every component that changes, every file path that is touched, and every component that explicitly does not change. Where an existing file is the template for a new one, that relationship is called out.
+
+### 3.1 `loom-tools` — new tool
+
+**New file:** `repos/bitswell/loom-tools/src/tools/stack-worker-init.ts`
+
+**Role:** `worker-stack-driver` (newly introduced — see §3.2).
+
+**Template:** modelled on `repos/bitswell/loom-tools/src/tools/pr-create.ts`, with the following differences:
+
+1. The `roles` field is `['worker-stack-driver']`, not `['orchestrator']`.
+2. The tool does not wrap `gh pr create`. It wraps the `gh stack` subcommand tree.
+3. The input schema takes an `op` discriminator (`'init' | 'add' | 'rebase' | 'rebase-continue' | 'rebase-abort' | 'submit' | 'sync' | 'push' | 'view' | 'checkout' | 'up' | 'down' | 'top' | 'bottom' | 'unstack'`) plus per-op arguments. Each op invocation is non-interactive (SKILL §"Agent rules") and auto-stamps a `Stack-Op:` trailer on the commit that follows.
+4. The handler refuses to run if `ctx.assignment` does not carry `Stack-Epic: true`. This is the single defense that keeps non-stack workers from calling into the `gh stack` subcommand tree.
+5. The handler refuses `submit` unless `--auto --draft` is set. Non-draft submission is reserved for integration-time GitHub state changes, which are still orchestrator-only.
+
+**Registration:** added to `repos/bitswell/loom-tools/src/tools/index.ts` alongside existing exports. No other tools are renamed or removed.
+
+**Unchanged tools:**
+
+- `repos/bitswell/loom-tools/src/tools/pr-create.ts` — `roles: ['orchestrator']` stays. Non-stack PR creation is still orchestrator-only.
+- `repos/bitswell/loom-tools/src/tools/pr-retarget.ts` — `roles: ['orchestrator']` stays. Stack bases are set by `gh stack submit`, not `pr-retarget`, so there is no overlap with the new tool.
+- `repos/bitswell/loom-tools/src/tools/dag-check.ts` — no changes to the topological sort. For stack epics the sort runs over a single assignment whose `Stack-Position:` trailer declares the layer order, so the existing algorithm returns `[layer-1, layer-2, layer-3, ...]` unchanged.
+
+### 3.2 Role enum expansion
+
+**File:** `repos/bitswell/loom-tools/src/types/tool.ts`
+
+**Current state:** `roles` is effectively binary — tools are either `['orchestrator']` (see `pr-create.ts` line 27) or unrestricted. The type definition that gates this is the `roles` field on the `ToolDefinition` interface.
+
+**Change:** add a third role value, `worker-stack-driver`, as a strict superset of `worker` for stack-epic assignments only.
+
+```ts
+// repos/bitswell/loom-tools/src/types/tool.ts (amended)
+export type Role = 'orchestrator' | 'worker' | 'worker-stack-driver';
+export interface ToolDefinition<I, O> {
+  name: string;
+  description: string;
+  inputSchema: z.ZodType<I>;
+  outputSchema: z.ZodType<O>;
+  roles: Role[];
+}
+```
+
+**Enforcement:** the MCP dispatch layer already checks `roles` on every tool call and rejects unauthorised callers. The new role value is checked the same way. A worker running without `Stack-Epic: true` cannot successfully call `stack-worker-init` because the handler refuses and because the dispatch guard blocks the `worker-stack-driver` role from being asserted on non-stack-epic sessions.
+
+### 3.3 Plugin / loom skill surface
+
+**File:** new recipe — `/home/willem/.claude/plugins/cache/loom-plugin/loom/0.1.0/skills/loom/references/stack-epic-recipe.md`
+
+This recipe is loaded by the orchestrator during decomposition when an epic is identified as stack-mode. It describes:
+
+1. How to identify a stack epic (the heuristic: at least two layers with linear dependencies and a shared reviewer).
+2. How to emit a `Stack-Epic: true` ASSIGNED commit with `Stack-Position:` laid out.
+3. How to run cascading `--ff-only` integration (§4).
+4. How to reconstruct the audit trail post-integration via `git log --format='%(trailers:key=Stack-Op)'`.
+
+**File:** amendment to `/home/willem/.claude/plugins/cache/loom-plugin/loom/0.1.0/skills/loom/references/worker-template.md`
+
+Add **Section 10 — "Stack-epic workers"** which overrides Section 9 ("Scope Enforcement") with the relaxed rules from §5 of this proposal. The amendment reads, in full:
+
+> **10. Stack-epic workers**
+>
+> If your AGENT.json's ASSIGNED commit carries `Stack-Epic: true`, the following overrides apply to §4 (Do the Work) and §9 (Scope Enforcement):
+>
+> 10.1. You are authorised to run `gh stack init`, `gh stack add`, `gh stack rebase` (including `--continue` and `--abort`), `gh stack submit --auto --draft`, `gh stack sync`, `gh stack view --json`, `gh stack push`, `gh stack checkout`, `gh stack up/down/top/bottom`, and `gh stack unstack` from inside your worktree. All other `gh` commands remain forbidden — in particular, `gh pr create`, `gh pr merge`, and `gh pr edit` are orchestrator-only.
+>
+> 10.2. Your scope (§9) is enforced as the *union* of all layer scopes declared in `Stack-Position`. Every commit on every branch you create via `gh stack add` is checked against this union at integration time.
+>
+> 10.3. Every `gh stack` command you run must be followed by a commit with a `Stack-Op: <op>` trailer. If the command produces no file changes, use `git commit --allow-empty` to keep the audit trail complete.
+>
+> 10.4. If a rebase conflicts, follow the SKILL's "Handle rebase conflicts" procedure: parse stderr, edit files, `git add`, `gh stack rebase --continue`, then commit with `Stack-Op: rebase-continue`. Do not force-push outside your stack's branch namespace.
+>
+> 10.5. Final submission is `gh stack submit --auto --draft` followed by a COMPLETED commit whose body lists the draft PR numbers. The orchestrator, not you, promotes drafts and merges.
+>
+> 10.6. You are the sole worker for the stack. Do not spawn sub-workers. Do not run `gh stack` commands on any stack whose namespace does not match `loom/<your-agent-id>-<assignment-slug>/*`.
+
+### 3.4 Schemas
+
+**File:** `/home/willem/.claude/plugins/cache/loom-plugin/loom/0.1.0/skills/loom/references/schemas.md`
+
+**Amendments:**
+
+- **§3.3 assignment trailers** — add:
+  - `Stack-Epic: true | false` — REQUIRED on stack-epic ASSIGNED commits, FORBIDDEN otherwise. Default value when omitted is `false`.
+  - `Stack-Position: <layer-1>,<layer-2>,...` — REQUIRED when `Stack-Epic: true`. Lists layer slugs in bottom-to-top order. Example: `Stack-Position: 1:auth-middleware,2:api-endpoints,3:frontend`.
+- **§3.2 state trailers** — add:
+  - `Stack-Op: init | add | rebase | rebase-continue | rebase-abort | submit | sync | push | view | checkout | up | down | top | bottom | unstack | commit` — REQUIRED on every commit a stack-epic worker makes that is not an IMPLEMENTING regular content commit. (Regular content commits carry `Stack-Op: commit` to keep the audit trail regular.)
+- **§4.1 required trailers per state** — extend the table for stack-epic branches:
+
+| State | Required trailers (stack-epic delta) |
+|-------|--------------------------------------|
+| ASSIGNED | `Stack-Epic: true`, `Stack-Position: <...>` |
+| IMPLEMENTING | `Stack-Op: <op>` on every commit |
+| COMPLETED | `Stack-Op: submit`, `Files-Changed: <n>`, `Key-Finding: <...>` at least once |
+
+Non-stack branches are unaffected.
+
+### 3.5 Worker template
+
+Already described in §3.3 above. To be explicit about the file: `/home/willem/.claude/plugins/cache/loom-plugin/loom/0.1.0/skills/loom/references/worker-template.md` gains a new §10 and picks up one-line cross-references in §4 ("If stack-epic, see §10") and §9 ("See §10 for the stack-epic override").
+
+### 3.6 Explicit no-change list
+
+- `repos/bitswell/loom-tools/src/tools/pr-create.ts` — no changes.
+- `repos/bitswell/loom-tools/src/tools/pr-retarget.ts` — no changes.
+- `repos/bitswell/loom-tools/src/tools/dag-check.ts` — no changes.
+- `repos/bitswell/loom-tools/src/tools/pr-merge.ts` — no changes.
+- `protocol.md §2` (state machine) — no textual change; the one-agent-per-branch rule is documented as having an exception carved out by §10 of the worker template, which is a reference change only.
+- `protocol.md §3.1` (assign) and `§3.2` (implement) — no changes to the state machine itself.
+- Everything outside the paths enumerated in §3.1–§3.5.
+
+---
+
+## 4. Branch naming and scope
+
+### 4.1 Branch naming convention
+
+LOOM's current convention is `loom/<agent>-<slug>`, one branch per assignment. For stack epics this proposal extends the convention to a compound form:
+
+```
+loom/<lead-agent>-<epic-slug>/<layer-slug>
+```
+
+- `<lead-agent>` is the single worker that owns the whole stack (see §4.2).
+- `<epic-slug>` is the assignment slug.
+- `<layer-slug>` is one of the layer names declared in `Stack-Position`.
+
+Concretely, for `ratchet` working on an auth epic with layers `auth-middleware`, `api-endpoints`, `frontend`:
+
+```
+loom/ratchet-auth-stack/auth-middleware   ← bottom
+loom/ratchet-auth-stack/api-endpoints
+loom/ratchet-auth-stack/frontend           ← top
+```
+
+`gh-stack`'s prefix mechanism lines up with this exactly. The SKILL §"Branch naming" and §"Prefix handling" rules say: *"Only pass the suffix when a prefix is set."* So the worker runs `gh stack init -p loom/ratchet-auth-stack auth-middleware`, which creates `loom/ratchet-auth-stack/auth-middleware`. Subsequent `gh stack add api-endpoints` creates `loom/ratchet-auth-stack/api-endpoints`. The `loom/` namespace is preserved, the `<lead-agent>-<epic-slug>/` grouping is preserved, and `gh-stack` does not need to be told anything about LOOM.
+
+### 4.2 One worker owns the whole stack
+
+This is a deliberate departure from LOOM's "one agent per branch" norm and it is worth stating in plain terms: **for a stack epic, one worker is assigned, and that worker creates and operates on multiple branches.**
+
+The rationale is forced by `gh-stack` itself. Three facts:
+
+1. **Exit code 8 — "Stack is locked".** `gh stack` uses a worktree-local lock file to serialize stack mutations. The SKILL documents this under *"Exit codes and error recovery"*. Two workers sharing a stack's branches but running from different worktrees would hit this lock every time either tried to `add` or `rebase`. Two workers running from the same worktree are not a LOOM-supported topology.
+2. **`git rerere` is worktree-local.** The SKILL's *"Rerere (conflict memory)"* note says: *"git rerere is enabled by init so previously resolved conflicts are auto-resolved in future rebases."* That cache lives in `.git/rr-cache` of the worktree doing the resolution. Spreading a stack across multiple worktrees throws the cache away.
+3. **Stack files are not designed for concurrent writers.** `gh-stack` represents the stack via a file in the repo state; no locking discipline exists for cross-worktree access.
+
+So the proposal commits to: one stack, one worker, one worktree. Layers are the worker's internal structure.
+
+### 4.3 Scope enforcement across a stack — the union-scope model
+
+LOOM's `protocol.md §6.1` rule reads:
+
+> **Agent scope** — An agent may modify only files matching its `Scope` trailer. The orchestrator verifies at integration.
+
+For stack-epic assignments, this is relaxed to a *union* scope model. The assignment's `Scope:` trailer is a union across every intended layer, and the orchestrator verifies at integration that every commit on every layer branch touches only files in the union.
+
+Concretely, an assignment with `Scope: src/auth/**, src/api/**, src/frontend/**, tests/**` and layer positions `1:auth-middleware,2:api-endpoints,3:frontend` permits:
+
+- commits on `loom/ratchet-auth-stack/auth-middleware` to touch any of `src/auth/**`, `src/api/**`, `src/frontend/**`, or `tests/**`.
+- commits on `loom/ratchet-auth-stack/api-endpoints` to touch any of the same.
+- commits on `loom/ratchet-auth-stack/frontend` to touch any of the same.
+
+A stricter per-layer trailer is **optional and advisory**:
+
+```
+Scope-Layer: 1:src/auth/**,tests/auth/**
+Scope-Layer: 2:src/api/**,tests/api/**
+Scope-Layer: 3:src/frontend/**,tests/frontend/**
+```
+
+If present, the orchestrator warns on integration when a layer's commits exceed the advisory scope, but it does not reject the stack as long as the union scope holds. Advisory scope is for review readability, not enforcement.
+
+### 4.4 Scope verification algorithm
+
+The verification algorithm at integration is:
+
+```python
+def verify_stack_scope(stack_assignment):
+    union = parse_scope(stack_assignment.trailers['Scope'])
+    layers = parse_stack_position(stack_assignment.trailers['Stack-Position'])
+
+    # 1. Enumerate all layer branches and verify they exist.
+    for layer in layers:
+        branch = f"loom/{stack_assignment.agent}-{stack_assignment.slug}/{layer.slug}"
+        require_branch_exists(branch)
+
+    # 2. Check every commit against the union scope.
+    assigned_sha = stack_assignment.assigned_commit_sha
+    for layer in layers:
+        branch = f"loom/{stack_assignment.agent}-{stack_assignment.slug}/{layer.slug}"
+        commits = git_commits_since(branch, assigned_sha)
+        for commit in commits:
+            for path in commit.files_changed:
+                if not matches_any(path, union):
+                    raise ScopeViolation(branch, commit.sha, path)
+
+    # 3. Verify Stack-Op trailers form a valid gh-stack sequence.
+    ops = collect_stack_ops_across_branches(layers, assigned_sha)
+    validate_stack_op_sequence(ops)  # init first, then adds, then rebases/commits, then submit
+
+    # 4. Verify Stack-Position trailer matches branch topology.
+    for i, layer in enumerate(layers):
+        parent = layers[i - 1].slug if i > 0 else 'main'
+        parent_branch = 'main' if i == 0 else f"loom/{stack_assignment.agent}-{stack_assignment.slug}/{parent}"
+        require_ancestor(parent_branch, branch)
+```
+
+Step 2 is where the "union" in "union scope" does its work: every commit on every branch is checked, just against the shared union rather than against each branch's own scope. This is *stricter* than per-branch scope in one sense (because every commit across every branch is checked) and *looser* in another (because the allowed path set is the union). The total surface area of "files a worker may touch" is exactly the same as the assignment's declared scope — the only thing that changes is how scope is partitioned across the worker's branches internally.
+
+### 4.5 Edge case: a worker rebases a layer whose advisory scope it does not own
+
+What if `ratchet` runs `gh stack down` to the `auth-middleware` layer and then accidentally commits a frontend change there?
+
+**Answer:** the commit lands on the wrong branch, `gh stack rebase --upstack` replays it as part of the stack, and integration step 2 of §4.4 catches the scope violation — *only* if the edited path is outside the union. If the edited path is inside the union, then the worker has mis-partitioned its work (a content quality issue, not a security issue). The *advisory* Scope-Layer trailers emit a warning to help reviewers notice, but the commit is not rejected.
+
+This is a deliberate choice. The enforcement boundary is the union — the worker's total authority envelope — and the within-stack partitioning is a hygiene concern rather than an invariant concern. If LOOM wants per-layer enforcement later, `Scope-Layer` can be promoted from advisory to enforced with a one-line config change.
+
+### 4.6 Edge case: a worker force-pushes outside its stack namespace
+
+What if a compromised or buggy worker runs `git push --force origin main`? Or more realistically, force-pushes `loom/moss-other-assignment/foo`?
+
+**Answer:** integration-time verification enumerates only branches under `loom/<lead-agent>-<epic-slug>/*`. Any force-push outside that namespace is invisible to the stack-epic integrate step and must be caught by general LOOM invariants (branch-protection rules on `main`, orchestrator-only integration for other agents' branches, etc.). This proposal does not relax protections on branches outside the stack's namespace. The `worker-stack-driver` role grants force-push authority only within the stack namespace because `stack-worker-init` only calls `gh stack` against that namespace; a raw `git push --force` is not exposed by the tool. A worker bypassing the tool via raw shell is caught by the existing audit trail and rolled back at integration — see §5's failure modes.
+
+---
+
+## 5. Worker authority — the core section
+
+This is the load-bearing section. Every other section of this proposal is downstream of the trust-boundary rethink here. This section was written first.
+
+### 5.1 What workers gain the right to do
+
+Workers assigned to a stack epic (i.e. whose ASSIGNED commit carries `Stack-Epic: true`) gain the right to run **every `gh stack` subcommand**, and only `gh stack` subcommands. Exhaustively:
+
+| Command | Purpose |
+|---------|---------|
+| `gh stack init -p loom/<lead>-<epic> <bottom-layer>` | Create the stack |
+| `gh stack add <layer-suffix>` | Add a layer on top of the current topmost |
+| `gh stack rebase` | Rebase the whole stack on the latest trunk |
+| `gh stack rebase --upstack` | Rebase everything from current layer upward |
+| `gh stack rebase --downstack` | Rebase everything from trunk to current layer |
+| `gh stack rebase --continue` | Resume after resolving conflicts |
+| `gh stack rebase --abort` | Roll back to pre-rebase state |
+| `gh stack sync` | Fetch, ff trunk, cascade rebase, push, sync PR state |
+| `gh stack push` | Force-with-lease push all layer branches atomically |
+| `gh stack submit --auto --draft` | Push and create draft PRs for every layer |
+| `gh stack view --json` | Query stack topology and PR state |
+| `gh stack checkout <branch>` | Navigate to a specific layer by name |
+| `gh stack up`, `gh stack down` | Navigate one layer at a time |
+| `gh stack top`, `gh stack bottom` | Navigate to extremes |
+| `gh stack unstack` | Tear down the stack (for restructuring) |
+
+Workers do **not** gain the right to run any non-`gh stack` GitHub write:
+
+- `gh pr create` — forbidden. Draft PRs for the stack come from `gh stack submit --auto --draft` only.
+- `gh pr merge` — forbidden. All merges go through orchestrator integration.
+- `gh pr edit` — forbidden. PR metadata edits are orchestrator-only.
+- `gh pr review`, `gh pr close`, `gh issue ...` — forbidden.
+- Any raw `git push` to a branch outside `loom/<lead-agent>-<epic-slug>/*` — forbidden.
+- Any `gh api` invocation — forbidden.
+
+The grant is scoped to the `gh stack` subcommand tree, mediated through the `stack-worker-init` tool which both enforces "only `gh stack` ops run here" and stamps `Stack-Op:` trailers on the commits that follow. A worker invoking raw `gh stack` directly (bypassing the tool) produces commits without `Stack-Op:` trailers, which the integration step rejects.
+
+### 5.2 Which LOOM invariants are relaxed (named, quoted, justified)
+
+Each relaxation below quotes the exact invariant it affects, cites the file and section, and justifies why the relaxation is forced by the angle.
+
+#### 5.2.1 `protocol.md §6.1` — "Workspace write"
+
+**Original text:**
+> **Workspace write** — Only the orchestrator writes to the workspace. Agents MUST NOT.
+
+**Relaxation:** Workers do not write to the *primary* workspace (that rule is preserved — workers still commit only inside their worktrees). What changes is that *force-pushes to remote refs under `loom/<lead-agent>-<epic-slug>/*` are now permitted for `worker-stack-driver` role*. Previously those remote refs were part of the orchestrator's exclusive write surface.
+
+**Justification:** `gh stack rebase` rewrites history and force-pushes by design. The SKILL's `gh stack push` entry says *"Pushes all active (non-merged) branches atomically (`--force-with-lease --atomic`)"*. Forcing this through the orchestrator means the orchestrator would need to copy the worker's `.git/rr-cache` over (which leaks worktree internals), re-drive the rebase, and hold state across possibly multi-step conflict resolution. All of that is possible in principle but makes context compaction fatal: if the orchestrator loses mid-rebase state, it cannot recover without the worker's `rerere` cache, and LOOM has no protocol for shipping caches across process boundaries.
+
+The relaxation is bounded: workers force-push *only* to refs under their epic's namespace, and only through the `stack-worker-init` tool (which only calls `gh stack` subcommands). A worker that bypasses the tool with raw `git push --force` is caught by the integration-time audit check, which enumerates expected force-push events from `Stack-Op:` trailers and rejects any branch whose reflog includes unexpected force-pushes.
+
+#### 5.2.2 `protocol.md §6.1` — "Agent scope"
+
+**Original text:**
+> **Agent scope** — An agent may modify only files matching its `Scope` trailer. The orchestrator verifies at integration.
+
+**Relaxation:** The `Scope:` trailer for a stack-epic assignment is a *union* across all layers. The orchestrator verifies at integration that every commit on every layer branch touches only files in the union — the verification algorithm in §4.4 is stricter than today in that it checks every commit on every branch, but it is looser in that the target set is the union rather than a per-branch subset.
+
+**Justification:** `gh stack` is fundamentally a mechanism for *partitioning* work across branches. A worker cannot know in advance which files belong to which layer without having done the work; forcing per-layer scope upfront means either the worker rejects its own assignment or the orchestrator has to re-issue scope on every mid-stack edit. The union model accepts the partition as a worker-side decision while preserving the total envelope of "which files the assignment is allowed to touch." Nothing the worker can do expands the total envelope.
+
+#### 5.2.3 `protocol.md §3.3` — `integrate()` `--no-ff` merge
+
+**Original text:** the `integrate()` procedure in `protocol.md §3.3` reads (paraphrasing, since the exact text is in the protocol file):
+> The orchestrator merges an agent's branch into the workspace. Integration is sequential and atomic.
+
+with the implicit rule that the merge is `--no-ff` so the merge commit records the integration in the first-parent history. This is the clause being relaxed.
+
+**Relaxation:** For stack-epic branches, `integrate()` is replaced with a **cascading fast-forward merge**. The orchestrator runs, in order:
+
+```sh
+git checkout main
+git merge --ff-only loom/<lead>-<epic>/<layer-1>   # bottom
+git merge --ff-only loom/<lead>-<epic>/<layer-2>
+git merge --ff-only loom/<lead>-<epic>/<layer-3>   # top
+```
+
+No merge commits are created. Every integrated commit is a worker commit with `Agent-Id`, `Session-Id`, and `Stack-Op` trailers.
+
+**Justification:** `gh stack` rebases and force-pushes by design. After `gh stack submit --auto --draft`, the stack's branches have been rebased on top of `main` and force-pushed. The original ASSIGNED commit is no longer an ancestor of the worker's branches — it was rewritten out of history during the first rebase. `--no-ff` merge requires the ASSIGNED commit to be a parent of the branch being merged, which is no longer true. So `--no-ff` is structurally impossible for stack-epic branches unless LOOM refuses to let workers rebase, which is exactly the "convention-only recipe" rejected alternative.
+
+The relaxation is *audit-preserving*, not *audit-destroying*. See §5.3.
+
+#### 5.2.4 `pr-create.ts` — `roles: ['orchestrator']` precedent
+
+**Source:** `/home/willem/bitswell/bitswell/repos/bitswell/loom-tools/src/tools/pr-create.ts` line 27.
+
+**Original state:** `roles: ['orchestrator']`. Every PR creation goes through the orchestrator.
+
+**Relaxation:** the existing guard on `pr-create` stays in force. The new `stack-worker-init` tool is registered with `roles: ['worker-stack-driver']`, a role that does not yet exist in `repos/bitswell/loom-tools/src/types/tool.ts` and which this proposal adds. The role is a strict superset of `worker` — it grants worker-level authority plus the `gh stack` subcommand tree.
+
+**Justification:** introducing a new role tier is the minimum change that lets the type system express the new trust boundary. Widening `worker` itself would grant stack authority to every worker, which violates least-privilege; leaving `worker` alone and using `orchestrator` for `stack-worker-init` just reproduces the MCP-wrapper alternative. A new role is the only thing that captures "elevated worker, but only for stack epics."
+
+#### 5.2.5 `worker-template.md §9` — "Scope Enforcement"
+
+**Original text:**
+> **9. Scope Enforcement**
+>
+> You MUST NOT modify files outside `scope.paths_allowed` in AGENT.json. The orchestrator verifies scope at integration and will reject the branch if any commit touches a file outside scope.
+
+**Relaxation:** overridden by the new §10 added in §3.3 of this proposal. For stack-epic workers, `scope.paths_allowed` is the union across layers, and the verification is performed against the entire set of layer branches rather than a single branch.
+
+**Justification:** the text of §9 is unchanged for non-stack workers. Stack-epic workers read §10, which explicitly redefines the enforcement envelope. There is no interpretation in which §9 and §10 conflict — §10 applies only when `Stack-Epic: true` is in the ASSIGNED commit, and §9 applies otherwise.
+
+#### 5.2.6 `protocol.md §2` — implicit one-agent-per-branch rule
+
+**Original text:** `protocol.md §2` describes the LOOM state machine in terms of *"one worker per assignment"*, and elsewhere in the protocol the assumption is that each assignment is paired with exactly one branch `loom/<agent>-<slug>`.
+
+**Relaxation:** one worker per stack-epic assignment is still preserved — the stack is owned by a single worker. The relaxation is that the worker is associated with multiple branches (the layer branches) under the same assignment. The ASSIGNED commit declares the stack by carrying `Stack-Epic: true` and listing the layer slugs in `Stack-Position:`.
+
+**Justification:** `gh-stack` requires one agent to drive a stack (see §4.2). Splitting the stack across multiple workers hits exit code 8 on every shared operation. The one-worker constraint is therefore forced, and allowing one worker to hold multiple branches is the minimum accommodation that lets LOOM describe what actually happens on disk.
+
+### 5.3 How scope enforcement still works when workers touch branches beyond their own
+
+A stack-epic worker touches multiple branches. "Branches beyond their own" is a misleading framing in this context — *all* the layer branches are the worker's own, because the worker is the sole owner of the stack. The scope envelope is the union; the verification algorithm is the one in §4.4; the failure modes are enumerated in §5.6.
+
+The sharper framing is: *what stops a stack-epic worker from force-pushing garbage onto another agent's branch?* Three mechanisms:
+
+1. **Tool scope.** `stack-worker-init` only runs `gh stack` subcommands against the stack identified by the active assignment. It does not expose raw `git push`, so there is no code path that force-pushes to an unrelated branch via the tool.
+2. **Namespace enforcement at integration.** The orchestrator enumerates only branches under `loom/<lead-agent>-<epic-slug>/*` when integrating the stack. Any other branch the worker may have touched is invisible to this integration and must be caught by general LOOM invariants (branch protection, orchestrator-only integration for other workers' branches, etc.).
+3. **Audit reconstruction.** Every legitimate force-push corresponds to a `Stack-Op: rebase` or `Stack-Op: submit` commit on one of the layer branches. At integration, the orchestrator walks `reflog` on each layer branch and cross-checks that every force-push event has a matching `Stack-Op` trailer. Unexpected force-pushes are rejected.
+
+### 5.4 How the audit trail is preserved
+
+LOOM's existing audit trail works by `--no-ff` merge commits on `main`: `git log --first-parent main` gives you a sequence of merge commits, each of which was an integration event, and each of those merge commits references an ASSIGNED commit via its non-first parent. This is the invariant §5.2.3 relaxes.
+
+The replacement is *trailer-based audit*. Every worker commit on every layer branch carries:
+
+- `Agent-Id: <worker>` — who made the commit
+- `Session-Id: <uuid>` — which work session
+- `Stack-Op: <op>` — what `gh stack` operation the commit represents
+- `Heartbeat: <timestamp>` — when the commit was made
+
+After cascading `--ff-only` integration, every one of those commits is now on `main` as a direct ancestor (not behind a merge commit). Reconstructing the audit trail becomes a `git log` query:
+
+```sh
+# Reconstruct the sequence of stack operations on main
+git log --first-parent main \
+  --format='%H %cI %s%n%(trailers:key=Agent-Id,key=Session-Id,key=Stack-Op)%n---'
+```
+
+Sample output (abbreviated from the §6 end-to-end example):
+
+```
+e5f1a21 2026-04-14T10:00:00Z chore(loom): begin auth-stack
+Agent-Id: ratchet
+Session-Id: c12e0e01-...
+Stack-Op: init
+---
+a3b7c82 2026-04-14T10:04:11Z feat(auth): add middleware core
+Agent-Id: ratchet
+Session-Id: c12e0e01-...
+Stack-Op: commit
+---
+d9f2118 2026-04-14T10:07:32Z chore(loom): stack add api-endpoints
+Agent-Id: ratchet
+Session-Id: c12e0e01-...
+Stack-Op: add
+---
+... etc ...
+---
+72ab3f1 2026-04-14T11:42:17Z feat(auth-stack): submit draft stack
+Agent-Id: ratchet
+Session-Id: c12e0e01-...
+Stack-Op: submit
+```
+
+Compare this with the `--no-ff` merge-commit audit: that format tells you *when a branch landed*, but nothing about *when commits were rebased, when conflicts were recovered, or when layers were reordered mid-work*. Those are rewritten-history events that `--no-ff` cannot represent because they happened before the merge. The trailer-based audit *does* represent them, because every rebase step is a `Stack-Op: rebase` commit with its own timestamp.
+
+In other words: the trailer-based audit is strictly *more informative* than `--no-ff` merge structure. It records the full history of the work, including the rebases, not just the final landing event. The reviewer of this proposal should evaluate whether that is a fair trade for the loss of merge-commit structure on `main`. This proposal asserts that it is, because the thing LOOM's audit trail is *for* is reconstructing what a worker did during the work — and rebases are part of the work.
+
+### 5.5 The new trust tier: `worker-stack-driver`
+
+Introduce the concept explicitly: `worker-stack-driver` is a new role tier in `repos/bitswell/loom-tools/src/types/tool.ts`. It is a strict superset of `worker` with one additional privilege: the authority to run the `gh stack` subcommand tree from within the worker's worktree, and to force-push to remote refs within the stack's `loom/<lead-agent>-<epic-slug>/*` namespace.
+
+This privilege is granted **only** when the worker's active assignment carries `Stack-Epic: true`. A worker receiving a regular (non-stack) assignment remains on the old `worker` tier and cannot call `stack-worker-init`. The MCP dispatch layer checks this on every tool call.
+
+The orchestrator's ASSIGNED commit is the sole point that grants this privilege. There is no other code path by which a worker becomes `worker-stack-driver`. An orchestrator that does not issue `Stack-Epic: true` can be confident no worker will ever run `gh stack`.
+
+### 5.6 The orchestrator's retained authority
+
+The orchestrator retains exclusive authority over:
+
+1. **Assignment creation.** Every ASSIGNED commit is orchestrator-only. Workers cannot self-promote into `worker-stack-driver`.
+2. **Stack-epic classification.** The decision of whether an epic is a stack epic belongs to the orchestrator alone. It is encoded in the `Stack-Epic: true` trailer on the ASSIGNED commit.
+3. **Scope verification at integration.** The algorithm in §4.4 is run by the orchestrator. Workers do not verify their own scope.
+4. **Cascading `--ff-only` integration.** The orchestrator runs the cascading merge into `main`. Workers never touch `main`.
+5. **Non-stack PR creation via `pr-create`.** Workers have no authority to create non-stack PRs.
+6. **PR promotion, merging, and closing on GitHub.** `gh pr merge`, `gh pr close`, `gh pr edit` remain orchestrator-only. The draft PRs workers create via `gh stack submit --auto --draft` are promoted and merged by the orchestrator after integration succeeds.
+7. **The audit contract.** The orchestrator owns the rule that every integrated commit must carry `Agent-Id`, `Session-Id`, and `Stack-Op` trailers. Workers that fail to stamp trailers are rejected at integration.
+
+The summary: the orchestrator owns **contracts** (assignment, scope, integration, audit). The worker owns **mechanics** (commits, branches, rebases, submission). This is the trust-boundary rethink, stated precisely.
+
+### 5.7 The answer to the trust-model question
+
+*What happens to LOOM's trust model when we let workers drive stacking?*
+
+**The trust model shifts from mechanism control to contract control. The orchestrator stops being a bottleneck for mechanical operations and becomes a verifier of worker outputs. The orchestrator owns the scope contract, the integration contract, and the audit contract; workers own the mechanics within those contracts. Any operation that is purely mechanical — rebasing, force-pushing within a bounded namespace, submitting draft PRs — is delegated to the worker because the worker is the party holding the working tree, the rerere cache, and the conflict-resolution context. Any operation that touches the global state of `main`, the GitHub merge queue, or the cross-worker state of the repo remains orchestrator-only because those operations require cross-agent authority the worker does not have.**
+
+This paragraph is the closing of §5 and should be read as the single-paragraph version of the entire proposal.
+
+### 5.8 Failure modes
+
+Four failure modes the proposal must address explicitly:
+
+#### 5.8.1 A worker force-pushes outside its stack namespace
+
+**Scenario:** compromised or buggy worker runs `git push --force origin main` or force-pushes to some other agent's branch.
+
+**Detection:** integration-time verification enumerates only branches under `loom/<lead-agent>-<epic-slug>/*`. Any out-of-namespace push is invisible to stack integration and must be caught by general LOOM invariants — branch protection on `main`, orchestrator-only integration for other agents' branches, and `gh` auth scopes on the worker's token.
+
+**Mitigation:** the `stack-worker-init` tool does not expose raw `git push`. A worker invoking raw `git push --force` from shell is caught by the audit reconstruction (§5.3): every legitimate force-push corresponds to a `Stack-Op: rebase` or `Stack-Op: submit` commit, and unexpected reflog entries are rejected.
+
+#### 5.8.2 A worker runs `gh stack submit --auto` without `--draft`
+
+**Scenario:** the worker creates non-draft PRs, bypassing the orchestrator's exclusive authority over promoting drafts to ready.
+
+**Detection:** integration rejects any branch under the stack namespace whose PR is non-draft unless the orchestrator itself promoted it. The orchestrator queries `gh stack view --json` before integrating and fails loudly if any PR is in an unexpected state.
+
+**Mitigation:** `stack-worker-init` refuses to run `submit` without `--draft`. A worker bypassing via raw `gh stack submit --auto` is caught at detection.
+
+#### 5.8.3 A worker invokes `gh pr create` instead of `gh stack submit`
+
+**Scenario:** worker shell-invokes `gh pr create` to make a non-stack PR under the epic namespace.
+
+**Detection:** integration enumerates all PRs under the epic namespace and requires every one to have been created by `gh stack submit` (identifiable by `gh stack view --json`'s PR metadata — stacked PRs are linked together via GitHub's stacks feature, non-stacked PRs are not).
+
+**Mitigation:** the `stack-worker-init` tool does not expose `pr create`; the raw-shell bypass is caught at integration. Additionally, the epic's branch-protection ruleset can be configured to require stack-created PRs only (a repo-level config, not a protocol change).
+
+#### 5.8.4 A worker gets compacted mid-rebase
+
+**Scenario:** the worker is in the middle of `gh stack rebase --continue` when context compaction happens. State on disk: partially resolved conflicts, `git rerere` cache populated, `REBASE_HEAD` set.
+
+**Recovery:** the SKILL's "Handle rebase conflicts" workflow is explicitly designed to be recoverable from disk state. Worker template §10 prescribes the recovery procedure: re-read the worktree state, check for `REBASE_HEAD`, parse any outstanding conflicted files, resolve them, and run `gh stack rebase --continue`. The `rerere` cache makes most re-runs of previously-resolved conflicts automatic.
+
+**Audit:** even a compacted-and-recovered worker leaves a trail of `Stack-Op: rebase` and `Stack-Op: rebase-continue` commits in the layer branches' reflogs. The orchestrator can reconstruct the full sequence from trailers at integration.
+
+---
+
+## 6. End-to-end example
+
+The canonical three-layer epic, traced concretely. The worker is `ratchet`. The epic is a three-layer auth feature: `auth-middleware → api-endpoints → frontend`.
+
+### 6.1 Epic decomposition (orchestrator)
+
+The orchestrator identifies the epic as a stack epic and emits a single ASSIGNED commit on `loom/ratchet-auth-stack`:
+
+```
+task(ratchet): stack epic — auth middleware → api endpoints → frontend
+
+Three-layer stack. Auth middleware is foundational (touches src/auth/**),
+api-endpoints consumes the middleware (src/api/**), frontend consumes the
+api (src/frontend/**). Shared test coverage in tests/**.
+
+Each layer should be its own reviewable PR. Use gh stack for layering.
+
+Agent-Id: bitswell
+Session-Id: c12e0e01-1a2b-4c3d-9e8f-011223344556
+Task-Status: ASSIGNED
+Assigned-To: ratchet
+Assignment: auth-stack
+Stack-Epic: true
+Stack-Position: 1:auth-middleware,2:api-endpoints,3:frontend
+Scope: src/auth/**, src/api/**, src/frontend/**, tests/**
+Dependencies: none
+Budget: 120000
+Epic: #74
+```
+
+Only *one* branch is created at assignment time — `loom/ratchet-auth-stack`. The worker will create the layer branches itself via `gh stack add`.
+
+### 6.2 Worker start
+
+The orchestrator dispatches `ratchet` into the worktree `loom/ratchet-auth-stack`. The worker reads the ASSIGNED commit, sees `Stack-Epic: true`, loads `worker-template.md §10`, and begins:
+
+```sh
+# worker's first action: IMPLEMENTING state commit with Stack-Op: init
+git commit --allow-empty -m "$(cat <<'EOF'
+chore(loom): begin auth-stack
+
+Agent-Id: ratchet
+Session-Id: c12e0e01-1a2b-4c3d-9e8f-011223344556
+Task-Status: IMPLEMENTING
+Heartbeat: 2026-04-14T10:00:00Z
+Stack-Op: init
+EOF
+)"
+
+# initialize the stack with the bottom layer
+gh stack init -p loom/ratchet-auth-stack auth-middleware
+# → creates loom/ratchet-auth-stack/auth-middleware and checks it out
+```
+
+### 6.3 Layer 1 — `auth-middleware`
+
+Ratchet writes the auth middleware, commits it:
+
+```sh
+# write src/auth/middleware.ts and tests/auth/middleware.test.ts
+git add src/auth/middleware.ts tests/auth/middleware.test.ts
+git commit -m "$(cat <<'EOF'
+feat(auth): add middleware core
+
+Signature validation, token parsing, request.auth binding.
+
+Agent-Id: ratchet
+Session-Id: c12e0e01-1a2b-4c3d-9e8f-011223344556
+Task-Status: IMPLEMENTING
+Heartbeat: 2026-04-14T10:04:11Z
+Stack-Op: commit
+EOF
+)"
+
+# more commits on the same layer as needed
+git add src/auth/types.ts
+git commit -m "$(cat <<'EOF'
+feat(auth): add shared types
+
+Agent-Id: ratchet
+Session-Id: c12e0e01-1a2b-4c3d-9e8f-011223344556
+Task-Status: IMPLEMENTING
+Heartbeat: 2026-04-14T10:06:47Z
+Stack-Op: commit
+EOF
+)"
+```
+
+### 6.4 Layer 2 — `api-endpoints`
+
+Ratchet adds the next layer and writes the API code:
+
+```sh
+gh stack add api-endpoints
+# → creates loom/ratchet-auth-stack/api-endpoints on top of auth-middleware
+
+git commit --allow-empty -m "$(cat <<'EOF'
+chore(loom): stack add api-endpoints
+
+Agent-Id: ratchet
+Session-Id: c12e0e01-1a2b-4c3d-9e8f-011223344556
+Task-Status: IMPLEMENTING
+Heartbeat: 2026-04-14T10:07:32Z
+Stack-Op: add
+EOF
+)"
+
+# write src/api/users.ts, src/api/sessions.ts, tests/api/...
+git add src/api/users.ts src/api/sessions.ts tests/api/users.test.ts tests/api/sessions.test.ts
+git commit -m "$(cat <<'EOF'
+feat(api): user and session endpoints
+
+Agent-Id: ratchet
+Session-Id: c12e0e01-1a2b-4c3d-9e8f-011223344556
+Task-Status: IMPLEMENTING
+Heartbeat: 2026-04-14T10:21:03Z
+Stack-Op: commit
+EOF
+)"
+```
+
+### 6.5 Mid-stack edit
+
+While writing the API layer, ratchet realises the middleware needs a new helper (`requireAuth(scope)`). This is the operation that `gh stack` exists for — and the operation that every non-worker-driven integration cannot handle.
+
+```sh
+# navigate down to the middleware layer
+gh stack down
+# → now on loom/ratchet-auth-stack/auth-middleware
+
+git commit --allow-empty -m "$(cat <<'EOF'
+chore(loom): stack down to auth-middleware
+
+Agent-Id: ratchet
+Session-Id: c12e0e01-1a2b-4c3d-9e8f-011223344556
+Task-Status: IMPLEMENTING
+Heartbeat: 2026-04-14T10:23:44Z
+Stack-Op: down
+EOF
+)"
+
+# add the helper
+git add src/auth/middleware.ts
+git commit -m "$(cat <<'EOF'
+feat(auth): add requireAuth(scope) helper
+
+Agent-Id: ratchet
+Session-Id: c12e0e01-1a2b-4c3d-9e8f-011223344556
+Task-Status: IMPLEMENTING
+Heartbeat: 2026-04-14T10:24:19Z
+Stack-Op: commit
+EOF
+)"
+
+# rebase upstack so api-endpoints picks up the helper
+gh stack rebase --upstack
+# → rebases loom/ratchet-auth-stack/api-endpoints onto the updated auth-middleware
+
+git commit --allow-empty -m "$(cat <<'EOF'
+chore(loom): rebase upstack after middleware helper
+
+Agent-Id: ratchet
+Session-Id: c12e0e01-1a2b-4c3d-9e8f-011223344556
+Task-Status: IMPLEMENTING
+Heartbeat: 2026-04-14T10:25:12Z
+Stack-Op: rebase
+EOF
+)"
+
+# back to the top
+gh stack top
+# → now on loom/ratchet-auth-stack/api-endpoints (still top of stack so far)
+```
+
+At this point the commit graph looks like:
+
+```
+main
+ └── loom/ratchet-auth-stack/auth-middleware   (3 commits: middleware core, types, requireAuth helper)
+      └── loom/ratchet-auth-stack/api-endpoints (1 commit: user + session endpoints, rebased)
+```
+
+### 6.6 Layer 3 — `frontend`
+
+```sh
+gh stack add frontend
+# → creates loom/ratchet-auth-stack/frontend
+
+git commit --allow-empty -m "$(cat <<'EOF'
+chore(loom): stack add frontend
+
+Agent-Id: ratchet
+Session-Id: c12e0e01-1a2b-4c3d-9e8f-011223344556
+Task-Status: IMPLEMENTING
+Heartbeat: 2026-04-14T10:28:01Z
+Stack-Op: add
+EOF
+)"
+
+# write src/frontend/auth-form.tsx, src/frontend/session-manager.ts, tests/frontend/...
+git add src/frontend/auth-form.tsx src/frontend/session-manager.ts tests/frontend/auth-form.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(frontend): auth form and session manager
+
+Agent-Id: ratchet
+Session-Id: c12e0e01-1a2b-4c3d-9e8f-011223344556
+Task-Status: IMPLEMENTING
+Heartbeat: 2026-04-14T10:48:56Z
+Stack-Op: commit
+EOF
+)"
+```
+
+### 6.7 Conflict recovery
+
+Ratchet realises the session-manager also needs a change in the API layer. Navigate down, edit, rebase — but this time a conflict hits during the rebase:
+
+```sh
+gh stack checkout loom/ratchet-auth-stack/api-endpoints
+# → navigate directly to the API layer
+
+git add src/api/sessions.ts
+git commit -m "$(cat <<'EOF'
+feat(api): add /sessions/refresh endpoint
+
+Agent-Id: ratchet
+Session-Id: c12e0e01-1a2b-4c3d-9e8f-011223344556
+Task-Status: IMPLEMENTING
+Heartbeat: 2026-04-14T10:54:03Z
+Stack-Op: commit
+EOF
+)"
+
+gh stack rebase --upstack
+# → fails with exit code 3, conflict in src/frontend/session-manager.ts
+```
+
+SKILL's "Handle rebase conflicts" workflow:
+
+```sh
+# read the conflicted file, resolve markers, stage
+git add src/frontend/session-manager.ts
+
+gh stack rebase --continue
+# → exit 0
+
+git commit --allow-empty -m "$(cat <<'EOF'
+chore(loom): rebase-continue after session-manager conflict
+
+Resolved markers in src/frontend/session-manager.ts. rerere
+cached the resolution.
+
+Agent-Id: ratchet
+Session-Id: c12e0e01-1a2b-4c3d-9e8f-011223344556
+Task-Status: IMPLEMENTING
+Heartbeat: 2026-04-14T10:57:41Z
+Stack-Op: rebase-continue
+EOF
+)"
+```
+
+### 6.8 Submit
+
+```sh
+gh stack top
+gh stack submit --auto --draft
+# → pushes loom/ratchet-auth-stack/{auth-middleware,api-endpoints,frontend}
+# → creates three draft PRs
+# → links them as a stack on GitHub
+
+git commit --allow-empty -m "$(cat <<'EOF'
+feat(auth-stack): submit draft stack
+
+Three-layer auth feature, draft PRs:
+
+- #210 loom/ratchet-auth-stack/auth-middleware (base: main)
+- #211 loom/ratchet-auth-stack/api-endpoints (base: auth-middleware)
+- #212 loom/ratchet-auth-stack/frontend (base: api-endpoints)
+
+Agent-Id: ratchet
+Session-Id: c12e0e01-1a2b-4c3d-9e8f-011223344556
+Task-Status: COMPLETED
+Files-Changed: 12
+Key-Finding: three draft PRs created, stack linked on GitHub
+Key-Finding: rerere cache caught one mid-rebase conflict in session-manager
+Heartbeat: 2026-04-14T11:42:17Z
+Stack-Op: submit
+EOF
+)"
+```
+
+At this point the worker is done. Ratchet does not promote the drafts, does not merge, does not edit PR metadata. Ratchet returns to the orchestrator.
+
+### 6.9 Integration phase (orchestrator)
+
+The orchestrator runs scope verification (algorithm in §4.4):
+
+1. Enumerate layer branches: `loom/ratchet-auth-stack/{auth-middleware,api-endpoints,frontend}`. All exist. ✓
+2. Check every commit against union scope `src/auth/**, src/api/**, src/frontend/**, tests/**`. Middleware commits touch `src/auth/**` and `tests/auth/**` — in scope. API commits touch `src/api/**` and `tests/api/**` — in scope. Frontend commits touch `src/frontend/**` and `tests/frontend/**` — in scope. ✓
+3. Verify `Stack-Op:` sequence: `init, commit, commit, add, commit, down, commit, rebase, add, commit, commit, rebase-continue, submit`. Valid `gh-stack` sequence. ✓
+4. Verify branch topology: api-endpoints has auth-middleware as ancestor, frontend has api-endpoints as ancestor. ✓
+
+Then cascading `--ff-only` merge:
+
+```sh
+git checkout main
+git pull --ff-only
+git merge --ff-only loom/ratchet-auth-stack/auth-middleware
+git merge --ff-only loom/ratchet-auth-stack/api-endpoints
+git merge --ff-only loom/ratchet-auth-stack/frontend
+git push origin main
+```
+
+Each merge is a fast-forward — no merge commit is created. The worker's commits are now direct ancestors of `main`.
+
+Finally, the orchestrator handles the GitHub PR state:
+
+- **Option A (auto-merge on GitHub):** promote each draft to ready (`gh pr ready`), merge in order via the merge queue. This preserves the PRs as visible artifacts but duplicates the local fast-forward.
+- **Option B (close-in-favor-of-push):** close each draft with a comment pointing to the fast-forwarded commits on `main`. This is cleaner on the local history but costs the PR audit trail on GitHub.
+
+This proposal picks **Option A**. The reason: PRs on GitHub are the review artifact reviewers actually look at, and closing them in favor of a direct push loses the review discussion. The cost of Option A is that the local `main` now has the commits before GitHub's merge queue processes them, so the merge queue has to no-op. For auto-merge queues this is acceptable; for strict linear-history queues it is not, in which case flip to Option B.
+
+### 6.10 Audit reconstruction
+
+After integration, the full worker sequence is reconstructable from `main`:
+
+```sh
+git log --first-parent main \
+  --format='%h %cI %s%n  %(trailers:key=Agent-Id,key=Stack-Op,separator=%x20)%n'
+```
+
+Sample output:
+
+```
+e5f1a21 2026-04-14T10:00:00Z chore(loom): begin auth-stack
+  Agent-Id: ratchet Stack-Op: init
+
+a3b7c82 2026-04-14T10:04:11Z feat(auth): add middleware core
+  Agent-Id: ratchet Stack-Op: commit
+
+72e4f19 2026-04-14T10:06:47Z feat(auth): add shared types
+  Agent-Id: ratchet Stack-Op: commit
+
+d9f2118 2026-04-14T10:07:32Z chore(loom): stack add api-endpoints
+  Agent-Id: ratchet Stack-Op: add
+
+b1c8923 2026-04-14T10:21:03Z feat(api): user and session endpoints
+  Agent-Id: ratchet Stack-Op: commit
+
+a8eb071 2026-04-14T10:23:44Z chore(loom): stack down to auth-middleware
+  Agent-Id: ratchet Stack-Op: down
+
+5f0a9c2 2026-04-14T10:24:19Z feat(auth): add requireAuth(scope) helper
+  Agent-Id: ratchet Stack-Op: commit
+
+4f1a803 2026-04-14T10:25:12Z chore(loom): rebase upstack after middleware helper
+  Agent-Id: ratchet Stack-Op: rebase
+
+3c9d217 2026-04-14T10:28:01Z chore(loom): stack add frontend
+  Agent-Id: ratchet Stack-Op: add
+
+e7b2541 2026-04-14T10:48:56Z feat(frontend): auth form and session manager
+  Agent-Id: ratchet Stack-Op: commit
+
+8d91f03 2026-04-14T10:54:03Z feat(api): add /sessions/refresh endpoint
+  Agent-Id: ratchet Stack-Op: commit
+
+21f7b1a 2026-04-14T10:57:41Z chore(loom): rebase-continue after session-manager conflict
+  Agent-Id: ratchet Stack-Op: rebase-continue
+
+72ab3f1 2026-04-14T11:42:17Z feat(auth-stack): submit draft stack
+  Agent-Id: ratchet Stack-Op: submit
+```
+
+Every stack op is captured. Every rebase is captured. Every conflict recovery is captured. The reviewer can replay the entire work session from the trailer trail, including events that `--no-ff` merge-commit structure *cannot* represent (the mid-work rebases).
+
+---
+
+## 7. Risks and rejected alternatives
+
+### 7.1 Risks
+
+**Risk 1 — a stack-epic worker misbehaves with elevated authority.** The worker has force-push authority within its namespace and draft-PR authority on GitHub. A malicious or buggy worker could in principle force-push garbage, submit non-draft PRs, or attempt to reach outside its namespace.
+
+*Mitigation:* integration-time scope verification against union scope catches content violations. `Stack-Op:` sequence validation catches protocol violations. Mandatory draft-only submission (enforced by `stack-worker-init` and re-checked at integration) catches ready-state violations. The attack surface is bounded to the worker's own stack namespace — the orchestrator still owns merges and cross-agent state.
+
+**Risk 2 — audit trail depends on trailer discipline.** If a worker forgets to stamp `Stack-Op:` trailers, the audit reconstruction loses fidelity. A silently dropped trailer might mask a rebase that changed semantics.
+
+*Mitigation:* `stack-worker-init` auto-stamps `Stack-Op:` trailers on the commit following every stack operation. Workers cannot run `gh stack` except through the tool (enforced by the `worker-stack-driver` role guard). A worker running raw `gh stack` from shell is caught at integration by the mismatched reflog: force-push events without corresponding `Stack-Op:` commits are rejected.
+
+**Risk 3 — one-worker-per-stack ceiling on parallelism.** Because the stack is serialized by construction (§4.2), a stack epic cannot be split across parallel workers. An epic with three layers is bound to one worker's throughput.
+
+*Mitigation:* this is a property of `gh-stack` itself (strictly linear stacks, worktree-local `rerere`, exit code 8), not of this proposal. Parallel epics that genuinely have independent dimensions should be split into separate stacks, each with its own worker. The "N parallel workers on N independent stacks" topology is supported.
+
+**Risk 4 — relaxing `--no-ff` weakens the audit invariant for stack-epic branches.** `main`'s first-parent history no longer has merge commits for integrations. Tools that walk `--first-parent` looking for "integration events" will find direct worker commits instead.
+
+*Mitigation:* this is a *deliberate trade*, not a concession. The replacement trailer-based audit is strictly more informative (§5.4). If a downstream tool assumes `--no-ff` structure, it must be updated to read trailers — which is a smaller change than losing `gh-stack` integration entirely. This proposal names the cost explicitly because pretending it is free would be dishonest and would damage the review process.
+
+**Risk 5 — worker context compaction during multi-step rebase.** A long rebase with multiple conflicts can span more work than a worker's context window, and compaction can happen mid-flow.
+
+*Mitigation:* SKILL's conflict workflow is explicitly designed to be recoverable from disk state. `REBASE_HEAD`, the `rerere` cache, and outstanding conflicted-file markers survive compaction. Worker template §10 prescribes the recovery procedure; the `rerere` cache means previously-resolved conflicts auto-resolve on re-run.
+
+**Risk 6 — GitHub stacks require repo-level feature enablement.** `gh stack submit --auto --draft` only links PRs as a stack on GitHub if the repo has stacks enabled.
+
+*Mitigation:* the stack-epic recipe (§3.3) includes a pre-flight check that verifies the repo has stacks enabled before issuing the ASSIGNED commit. If the repo does not, the orchestrator declines to decompose the epic as a stack epic and falls back to a non-stack decomposition.
+
+### 7.2 Rejected alternatives
+
+#### Rejected A — post-hoc projection (team 1's angle)
+
+**Mechanism:** workers commit a linear stream of work; the orchestrator projects a stack onto the commits after integration by cherry-picking into layered branches.
+
+**Why rejected:** post-hoc projection cannot handle mid-work conflict recovery or mid-stack edits, because the stack does not exist until after the work is done. Exactly the operations that justify stacking in the first place — navigating down to change a lower layer, rebasing upstack, resolving conflicts with `rerere` — are unavailable during the work. It solves the audit-trail problem (`--no-ff` is preserved by doing the integration first and then projecting) at the cost of the conflict-recovery problem. This proposal makes the opposite bet: pay the audit-structure cost to buy worker-driven conflict recovery, because conflict recovery is the thing that `gh-stack` is *for*.
+
+A secondary issue with post-hoc projection: it requires the orchestrator to impersonate the worker at the moment it creates the projected layers. GitHub sees the PRs as orchestrator-authored even though the commits are worker-authored. This damages the review audit on GitHub itself. Worker-side stacking keeps authorship honest because the worker is actually the author.
+
+#### Rejected B — orchestrator-only `gh stack` via MCP wrapper
+
+**Mechanism:** a new `stack-create`, `stack-add`, `stack-rebase`, `stack-submit` set of MCP tools, all with `roles: ['orchestrator']`. Workers commit content; the orchestrator wraps every stack op.
+
+**Why rejected:** every stack op becomes a round-trip through the orchestrator, which has no working tree and no `rerere` cache. Mid-rebase state (`REBASE_HEAD`, conflicted files, `rerere` cache) cannot be transferred across process boundaries without leaking `.git` internals, which LOOM's protocol forbids. Conflict recovery serializes on a process that may be compacted in the middle of the rebase, which silently destroys mid-flow state. And the orchestrator's latency per op adds up over a realistic stack's lifetime: a single stack epic with three layers, two mid-stack edits, and one rebase conflict generates ~20 `gh stack` invocations, each of which would be an orchestrator round-trip in this model.
+
+The deep issue is that `gh-stack` was designed for local-first, worktree-resident operation. Wrapping it in an RPC that strips it of its working tree defeats the point.
+
+#### Rejected C — keep orchestrator-only but pre-create all stack branches upfront
+
+**Mechanism:** the orchestrator runs `gh stack init` and `gh stack add` for every layer before the worker starts. The worker just commits to the pre-created branches. The orchestrator runs `gh stack submit` at the end.
+
+**Why rejected:** it cannot handle *any* mid-stack edit. If the worker on layer 3 needs to change layer 1, it has no tools to navigate down and rebase upstack — those are `gh stack` commands, which this alternative forbids. The worker either commits the change on the wrong layer (content ends up in the wrong PR), or gives up and asks the orchestrator to do it (which is rejected alternative B), or rejects its own assignment. This alternative works only for stacks that do not need mid-stack edits, which is approximately zero real stacks.
+
+Additionally: `gh stack submit` at the end assumes no conflicts. Any upstream move in `main` during the work invalidates the stack, and the orchestrator has no way to re-rebase without restarting the whole alternative-B round-trip dance.
+
+#### Rejected D — full `gh` grant to all workers (not just stack-epic)
+
+**Mechanism:** widen the `worker` role to include the entire `gh` CLI. Drop the `worker-stack-driver` tier — every worker can run `gh stack`, `gh pr`, `gh issue`, etc.
+
+**Why rejected:** massively wider blast radius for no benefit on non-stack assignments. A non-stack worker has no legitimate reason to run `gh pr create` (that is `pr-create`'s job) or `gh issue create` or `gh api`. Widening the grant unnecessarily violates least-privilege. The `worker-stack-driver` role exists precisely to scope the grant to the set of assignments that actually need it.
+
+A related rejection: "grant `gh stack` but not other `gh` subcommands to the `worker` role globally, without a new role tier." This is rejected because the MCP tool system's enforcement unit is the tool, not the subcommand. Expressing "this worker can run `gh stack` but not `gh pr create`" requires either two separate tools (which is what this proposal does) or a subcommand-level allowlist inside a monolithic `gh` tool (which is a much larger design change). The new role tier is cheaper and clearer.
+
+#### Rejected E — per-layer workers sharing a worktree via file locks
+
+**Mechanism:** N workers, each assigned to one layer, sharing a single worktree serialized by an external lock.
+
+**Why rejected:** LOOM's worker template assumes a worker owns its worktree exclusively — there is no sharing protocol, no lock, and no coordination primitives between workers. Introducing file-level locking is a protocol-wide change for a single-feature benefit. And the benefit is marginal because `gh stack`'s exit code 8 and `rerere`'s worktree-local cache would *still* force serialization; adding a file lock on top just reproduces §4.2's "one worker owns the stack" conclusion with more machinery.
+
+---
+
+## Appendix A — Referenced files
+
+All paths absolute unless marked `repo:`.
+
+- **Epic RFP:** `gh issue view 74 --repo bitswell/bitswell`
+- **gh-stack SKILL:** `/home/willem/.agents/skills/gh-stack/SKILL.md`
+- **LOOM protocol:** `/home/willem/.claude/plugins/cache/loom-plugin/loom/0.1.0/skills/loom/references/protocol.md` (§2 state machine, §3.3 integrate, §6.1 security)
+- **LOOM schemas:** `/home/willem/.claude/plugins/cache/loom-plugin/loom/0.1.0/skills/loom/references/schemas.md` (§3.2 state trailers, §3.3 assignment trailers, §4.1 required-per-state)
+- **LOOM worker template:** `/home/willem/.claude/plugins/cache/loom-plugin/loom/0.1.0/skills/loom/references/worker-template.md` (§4 Do the Work, §9 Scope Enforcement, proposed new §10)
+- **pr-create (role precedent):** `repo: repos/bitswell/loom-tools/src/tools/pr-create.ts` line 27
+- **pr-retarget (unchanged):** `repo: repos/bitswell/loom-tools/src/tools/pr-retarget.ts`
+- **dag-check (reused):** `repo: repos/bitswell/loom-tools/src/tools/dag-check.ts`
+- **Tool type (role enum amended):** `repo: repos/bitswell/loom-tools/src/types/tool.ts`
+- **Tool index (new registration):** `repo: repos/bitswell/loom-tools/src/tools/index.ts`
+- **New tool file:** `repo: repos/bitswell/loom-tools/src/tools/stack-worker-init.ts` (proposed)
+
+## Appendix B — The one-paragraph version
+
+For readers who want the whole proposal in one paragraph:
+
+> This proposal delegates `gh stack` authority to workers for stack-epic assignments. A new `worker-stack-driver` role is introduced in `repos/bitswell/loom-tools/src/types/tool.ts`, a new `stack-worker-init` MCP tool is added in `repos/bitswell/loom-tools/src/tools/`, and the worker template gains a §10 that relaxes workspace-write and scope-enforcement invariants for `Stack-Epic: true` assignments. Workers run `gh stack init/add/rebase/submit` from their worktrees, own their stack's `loom/<lead>-<epic>/*` namespace, and submit draft PRs only. Integration is cascading `--ff-only` merge into `main`, with audit preserved by `Stack-Op:` / `Agent-Id:` / `Session-Id:` / `Heartbeat:` trailers rather than by `--no-ff` merge-commit structure. The trust model shifts from *the orchestrator owns every GitHub write* to *the orchestrator owns the assignment/scope/integration/audit contracts; workers own the stack mechanics within those contracts*. The proposal is the only one of the five that names the cost of relaxing `--no-ff` directly, and it justifies that cost on the grounds that worker-driven mid-stack edits and conflict recovery are the entire reason `gh-stack` exists.

--- a/docs/rfcs/gh-stack-integration/team-4/review.md
+++ b/docs/rfcs/gh-stack-integration/team-4/review.md
@@ -1,0 +1,626 @@
+# Team 4 — Review (glitch)
+
+**Verdict:** APPROVED WITH EDITS — stays inside its angle, names the cost it's
+paying, but glosses over four concrete failure modes that would sink the
+implementation. Angle-fidelity is the strongest of the five teams. Execution
+honesty is weaker than the prose suggests.
+
+---
+
+## 1. Coverage audit
+
+All seven RFP sections are present and named by the correct headers:
+
+| # | Required section           | Present | Header in proposal                         |
+|---|----------------------------|---------|--------------------------------------------|
+| 1 | Angle statement            | yes     | §1. Angle statement                        |
+| 2 | Thesis                     | yes     | §2. Thesis                                 |
+| 3 | What changes               | yes     | §3. What changes                           |
+| 4 | Branch naming and scope    | yes     | §4. Branch naming and scope                |
+| 5 | Worker authority           | yes     | §5. Worker authority — the core section    |
+| 6 | End-to-end example         | yes     | §6. End-to-end example                     |
+| 7 | Risks and rejected alts    | yes     | §7. Risks and rejected alternatives        |
+
+Plus two appendices (A — referenced files, B — one-paragraph version). No
+section is missing. No section is thin; §5 is the longest and most detailed,
+which is appropriate given the outline named it the core.
+
+---
+
+## 2. Angle fidelity audit
+
+**Verdict: the angle holds, unbroken, across every section.**
+
+The outline's hard constraint was: "any sentence in this proposal implying
+workers do not run `gh stack` commands is a bug." I scanned every section
+looking for drift. I did not find any. Specific observations:
+
+- **§1** repeats the angle three times in different registers (mechanical,
+  architectural, reductive). The third register — *proximity of data beats
+  protocol purity* — is the shortest accurate summary of the angle I've seen
+  in any of the five proposals.
+- **§2** uses the four-way rejected-alternatives framing to pressure-test
+  its own angle by forcing every non-worker-driven path to explain how it
+  handles mid-stack edits. The argument is not subtle, but it is honest.
+- **§3** commits to file paths, role names, and tool names. No hand-waves
+  about "a new tool would be added somewhere." The file paths are mostly
+  right (one factual error; see §8 of this review).
+- **§4** names the one-worker-per-stack constraint and justifies it from
+  `gh-stack` internals (exit code 8, rerere locality, stack-file locking).
+  This is the most angle-dependent architectural claim in the proposal,
+  and it is argued from first principles rather than asserted.
+- **§5** is the load-bearing section. It names *six* LOOM invariants being
+  relaxed (workspace-write, agent-scope, `--no-ff` integration, the
+  orchestrator-only tool precedent, worker-template §9, and the implicit
+  one-agent-per-branch rule). Every one is quoted, cited, and justified.
+  No other team's proposal enumerates its invariant relaxations this
+  concretely.
+- **§6** traces the auth → api → frontend flow end-to-end with actual
+  `Stack-Op:` trailers, commit bodies, and a mid-stack edit followed by a
+  conflict recovery. The worker is the `gh stack` caller on every line.
+  There is no paragraph in which the orchestrator sneaks back into the
+  call path.
+- **§7** names rejected alternative A (post-hoc projection) and explicitly
+  says it solves the audit-trail problem at the cost of the
+  conflict-recovery problem. The inverse bet is stated directly.
+
+There is **no paragraph that implies workers do not drive `gh stack`**. If
+anything, the proposal overcommits to the angle — every failure mode is
+answered by adding more worker authority rather than retreating to the
+orchestrator. This is ideologically consistent, which is what the outline
+asked for.
+
+The only sentence that comes close to drift is in §6.9 Option A:
+
+> promote each draft to ready (`gh pr ready`), merge in order via the
+> merge queue
+
+This is orchestrator-driven PR promotion *after* worker-driven stacking,
+which is not drift — the angle is about the `gh stack` call path during
+the work, and PR promotion at the end is allowed. But it creates a
+correctness problem I'll address in §4 of this review (the double-apply
+between local ff-merge and GitHub merge queue).
+
+---
+
+## 3. Sharp-edge audit
+
+The RFP named five sharp edges. For each, I checked whether the proposal
+(a) explicitly names it, and (b) gives a non-hand-wavy answer. Verdict
+per edge:
+
+### Sharp edge 1 — `loom-tools` already supports custom bases
+
+**Proposal's answer:** not directly cited. The proposal talks about
+`pr-retarget.ts` as "no changes because stack bases are set by `gh stack
+submit`, not `pr-retarget`" (§3.1), but it does not engage with whether
+the existing custom-base support in `loom-tools` could be used *instead*
+of a new tool. This is a near-miss. A reviewer who believed custom-base
+support was load-bearing for the epic would not be convinced by §3.1.
+
+**Rating:** partially addressed; would benefit from one paragraph
+acknowledging the custom-base feature and explaining why it does not
+replace `stack-worker-init`.
+
+### Sharp edge 2 — Dependency DAG exists
+
+**Proposal's answer:** §3.1 and Appendix A reference `dag-check.ts`:
+*"the topological sort runs over a single assignment whose Stack-Position
+trailer declares the layer order, so the existing algorithm returns
+[layer-1, layer-2, layer-3] unchanged."*
+
+This is a crisp answer. It reuses the existing DAG machinery without
+rewriting it, by treating stack-position as an intra-assignment ordering.
+Good.
+
+**Rating:** fully addressed.
+
+### Sharp edge 3 — Branch naming conflict
+
+**Proposal's answer:** §4.1 extends the convention to
+`loom/<lead-agent>-<epic-slug>/<layer-slug>` and pins the `gh-stack`
+prefix (`-p loom/<lead>-<epic>`) to make the `/` separator structural,
+not accidental. §4.2 forces one worker per stack, which is how the
+proposal avoids cross-agent collisions on the same namespace.
+
+**Rating:** fully addressed for the single-worker case. **Not addressed
+for the orchestrator-error case** — see chaos finding §4.A below.
+
+### Sharp edge 4 — Merge vs rebase
+
+**Proposal's answer:** §4 opens with the required direct statement
+("This proposal breaks LOOM's `--no-ff` merge invariant for stack-epic
+branches, and here is why the trade is worth it") and §5.2.3 spells
+out cascading `--ff-only` as the replacement. The `--ff-only` → worker
+commits become direct ancestors of `main` → trailer-based audit chain is
+stated concretely in §5.4 with example `git log` output.
+
+**Rating:** fully addressed at the argument level. **Not addressed at the
+race-condition level** — see chaos finding §4.F below.
+
+### Sharp edge 5 — Worker-vs-orchestrator PR authority
+
+**Proposal's answer:** §5 is an entire section on this. The authority
+boundary is drawn as *contracts vs mechanics*: orchestrator owns
+assignments, scope, integration, and audit; worker owns commits,
+branches, rebases, and draft submission. §5.6 enumerates what the
+orchestrator retains. §5.8 enumerates four failure modes with
+mitigations.
+
+**Rating:** fully addressed at the angle level. This is the sharp edge
+the proposal was *built* to answer, and it answers it directly in the
+opposite direction from any other team. The "contracts vs mechanics"
+frame is genuinely new.
+
+**Sharp-edge summary:** 3 fully addressed, 2 partially. The two partials
+(custom-base and branch-naming cross-agent case) are fixable by
+paragraph-level additions, not structural changes.
+
+---
+
+## 4. Feasibility audit — chaos findings
+
+This is the section where the proposal's gloss peels off. I tried to break
+the proposal by imagining the worst adversary the proposal allows. Four
+findings are material; two are paper cuts.
+
+### 4.A. Two workers collide on the same stack namespace
+
+**What the proposal says:** one worker per stack (§4.2), justified by
+exit code 8, rerere locality, and stack-file locking. These are
+*intra-worker* guarantees — they explain why two workers *cannot*
+simultaneously operate on a shared worktree. They do **not** prevent two
+*different* orchestrator-issued assignments from using overlapping
+`loom/<lead-agent>-<epic-slug>/*` namespaces.
+
+**The failure mode the proposal doesn't see:** the proposal assumes
+namespace uniqueness is guaranteed by the orchestrator. It is not —
+the orchestrator's only uniqueness guarantee today is the `loom/<agent>-<slug>`
+prefix on the *primary* branch. There is no invariant preventing two
+concurrent assignments with identical `<agent>-<slug>` values (e.g., a
+retry after a failed assignment, or two orchestrator sessions racing on
+a shared repo). If that happens, both workers `gh stack init -p
+loom/ratchet-auth-stack auth-middleware` and then both force-push
+`loom/ratchet-auth-stack/auth-middleware` with `--force-with-lease`. The
+second push's lease is stale because the first push happened between
+fetches, so it fails loudly. But the first worker's rebase state (which
+includes the rerere cache for whatever conflicts it already resolved)
+is now on disk in a worktree the second worker cannot read, and the
+lease-failure error does not tell the second worker "you are a duplicate
+assignment — abort."
+
+**Worst case:** a retry-after-failure scenario. Worker A failed at 90%,
+orchestrator issues worker B with the same `(agent, slug)`. Worker B
+starts, finds `loom/ratchet-auth-stack/auth-middleware` already exists on
+remote, assumes it's its own work from a prior compaction, fetches it,
+and continues rebasing from worker A's last state. Worker A's state
+includes commits worker B did not make. Worker B's subsequent `Stack-Op:`
+trailers reference ops worker A performed. The audit trail is now
+mislabeled: `Agent-Id: ratchet` on commits worker-B's session didn't
+actually author.
+
+**What the proposal needs:** a collision-detection step in the ASSIGNED
+commit itself — orchestrator MUST verify no existing branches under the
+target namespace before emitting `Stack-Epic: true`, and MUST fail
+assignment (not silently overwrite) if any layer branch already exists.
+Add this to §5.6 as retained orchestrator authority.
+
+**Severity:** high. This is the single biggest hole.
+
+### 4.B. Force-push outside scope is post-detected, not prevented
+
+**What the proposal says:** §5.8.1 says a worker force-pushing outside
+its stack namespace is "caught by general LOOM invariants (branch
+protection on `main`, orchestrator-only integration for other agents'
+branches, and `gh` auth scopes on the worker's token)" and "caught at
+integration by mismatched reflog."
+
+**The failure mode the proposal doesn't see:** none of those mitigations
+are prevention. They are all detection, and detection happens *after*
+the force-push has already overwritten history. Specifically:
+
+1. **`gh auth` token scoping does not exist at the subcommand level.**
+   The `stack-worker-init` tool wraps `gh stack` ops, but the tool cannot
+   revoke the worker's shell access to raw `gh` or raw `git`. The
+   "worker-stack-driver" role is a tool-dispatch check, not an OS-level
+   capability. Any worker with shell access can run
+   `GH_TOKEN=<...> gh api -X DELETE /repos/.../branches/main` and the
+   tool cannot prevent it.
+2. **Branch protection on `main` is not a LOOM invariant today.** The
+   proposal says "must be caught by general LOOM invariants" but LOOM's
+   protocol.md does not mandate branch-protection rulesets. Some repos
+   have them, some don't.
+3. **Integration-time reflog check cannot undo an overwrite.** If worker
+   ratchet force-pushes `loom/moss-other-assignment/foo` to garbage at
+   time T1, and the orchestrator integrates moss's assignment at T2, moss's
+   work is already destroyed.
+
+**What the proposal needs:** either (a) an explicit dependency on
+branch-protection rulesets (and a pre-flight check that verifies they
+are in place before `Stack-Epic: true` is issued), or (b) an
+acknowledgement that the worker-stack-driver role is a trust tier, not
+a sandbox, and name the operational mitigations (monitoring, rollback
+procedures) that accompany trust grants.
+
+**Severity:** medium — the attack surface is bounded to *peer* workers,
+not `main`, in most configurations, but the proposal overstates the
+containment.
+
+### 4.C. `git_commits_since(branch, assigned_sha)` is uncomputable after rebase
+
+**What the proposal says:** §4.4 pseudocode, step 2:
+
+> ```
+> commits = git_commits_since(branch, assigned_sha)
+> ```
+
+where `assigned_sha` is the ASSIGNED commit that lives on `loom/<lead>-<epic>`.
+
+**The failure mode the proposal doesn't see:** in §5.2.3, the proposal
+already admits: *"The original ASSIGNED commit is no longer an ancestor
+of the worker's branches — it was rewritten out of history during the
+first rebase."* After rebase, `assigned_sha` is **not reachable** from
+any layer branch. Therefore `git log assigned_sha..layer-branch` is
+uncomputable; git returns either the empty set (if the SHAs are
+unrelated) or everything reachable from `layer-branch` (if you fall
+back to `git log layer-branch`).
+
+The integration scope-check algorithm in §4.4 depends on knowing which
+commits the worker authored. If you can't walk from the ASSIGNED sha,
+your alternatives are:
+
+- `git log main..layer-branch` — this catches only commits since the
+  orchestrator's last pull from `origin/main`, which may be stale or
+  ahead.
+- `git log --author=<agent>` — this trusts the commit header, which is
+  a weaker trust root than a sha.
+- `git log --grep='Agent-Id: <agent>'` — this trusts the trailer, which
+  is what the worker is stamping, i.e. circular.
+
+**What the proposal needs:** an explicit definition of the "fork point"
+used by scope verification after rebase. The most defensible choice is
+`merge-base(main, layer-branch)` *at the time the stack was submitted*,
+which means the orchestrator must capture a fork-point sha at
+`gh stack submit` time and verify against that. This is not expensive
+but it is a real protocol change the proposal does not specify.
+
+**Severity:** high. The scope-verification algorithm is the *key*
+defence the proposal relies on, and it's uncomputable as written.
+
+### 4.D. `Stack-Op:` trailers can be silently lost by rebase
+
+**What the proposal says:** §5.4 — *"every rebase step is a
+`Stack-Op: rebase` commit with its own timestamp."* §3.3 worker
+template §10.3 — *"Every `gh stack` command you run must be followed
+by a commit with a `Stack-Op: <op>` trailer. If the command produces
+no file changes, use `git commit --allow-empty` to keep the audit
+trail complete."*
+
+**The failure mode the proposal doesn't see:** `git rebase` (which
+powers `gh stack rebase`) drops empty commits by default unless
+`--keep-empty` is passed. `gh stack rebase` does not document whether
+it passes `--keep-empty` internally. The SKILL at line 628 documents
+that `gh stack rebase` *"handles squash-merge detection and correctly
+replays commits on top of the merge target"* — which means it is
+actively rewriting commit identities during rebase. If the worker runs
+`gh stack down` → `git commit --allow-empty -m '... Stack-Op: down'`
+→ (some time passes) → `gh stack rebase --upstack`, the empty
+`Stack-Op: down` commit may or may not survive the rebase. The
+proposal *assumes* it survives. I believe it likely does not: `git
+rebase` without `--keep-empty` drops empty commits, and `gh stack
+rebase` is a `git rebase` under the hood.
+
+**What the proposal needs:** either (a) `stack-worker-init` must set
+`GIT_REBASE_OPTS=--keep-empty` or inject `--keep-empty` into every
+rebase invocation, or (b) the audit design must stop relying on
+`--allow-empty` commits and switch to a trailer format that persists
+on real content commits only. The §6 end-to-end example uses empty
+commits for navigation ops (`down`, `top`, `add`, `init`) — every one
+of those is vulnerable to being dropped at the next rebase.
+
+**Severity:** high. The audit contract is specifically the contract
+the worker authority relaxation was supposed to preserve. A silent
+drop of navigation-op trailers breaks that preservation claim.
+
+### 4.E. `gh stack init` on an already-committed branch
+
+**What the proposal says:** §6.2 — worker commits
+`chore(loom): begin auth-stack` on `loom/ratchet-auth-stack`, then runs
+`gh stack init -p loom/ratchet-auth-stack auth-middleware`.
+
+**The failure mode the proposal doesn't see:** `gh stack init` creates
+a *new* branch. After the command, the worker is on
+`loom/ratchet-auth-stack/auth-middleware`. The ASSIGNED commit and the
+"begin auth-stack" commit both live on `loom/ratchet-auth-stack`, which
+is **not** one of the layer branches integration checks. `git merge
+--ff-only loom/ratchet-auth-stack/auth-middleware` into `main` does
+**not** bring the ASSIGNED commit along, because `auth-middleware` was
+forked from `main` at `gh stack init` time, not from the commit that
+carries `Stack-Epic: true`.
+
+**Consequences:**
+
+1. The ASSIGNED commit is never integrated. The audit trail on `main`
+   has no `Task-Status: ASSIGNED` entry, no `Stack-Epic: true`
+   declaration, no `Stack-Position:` trailer. The whole epic is
+   invisible in `git log main`.
+2. The `Scope:` trailer on the ASSIGNED commit is never in `main`'s
+   history. Scope reconstruction after-the-fact requires walking the
+   deleted `loom/ratchet-auth-stack` branch, which may not exist
+   post-integration.
+3. The state transition ASSIGNED → IMPLEMENTING → COMPLETED is visible
+   only on the *non-integrated* branch. The integrated history shows
+   only worker commits, no orchestrator assignment.
+
+**What the proposal needs:** the orchestrator must either (a) cherry-pick
+the ASSIGNED commit onto `main` as a separate "assignment record" commit
+before the cascading ff merge, (b) use `gh stack init --adopt` on an
+existing branch that already has the ASSIGNED commit, or (c) store the
+assignment record in a LOOM-managed side branch. None of these are
+specified in §4 or §6.9.
+
+**Severity:** high. This breaks the audit contract that the entire
+proposal leans on in §5.4.
+
+### 4.F. Cascading `--ff-only` races with upstream `main` moves
+
+**What the proposal says:** §6.9 —
+
+> ```sh
+> git checkout main
+> git pull --ff-only
+> git merge --ff-only loom/ratchet-auth-stack/auth-middleware
+> git merge --ff-only loom/ratchet-auth-stack/api-endpoints
+> git merge --ff-only loom/ratchet-auth-stack/frontend
+> ```
+
+**The failure mode the proposal doesn't see:** there is a time window
+between the worker's `gh stack submit --auto --draft` (which force-pushes
+all three layer branches after rebasing them onto `origin/main@T1`) and
+the orchestrator's integration (at `T2 > T1`). If any other branch
+merges to `main` in `[T1, T2]`, then `origin/main` has moved past the
+point the layer branches were rebased onto. The first `git merge
+--ff-only` fails loudly — layer-1 is not a fast-forward of the new main.
+
+**Mitigation options, none specified by the proposal:**
+
+1. Orchestrator re-runs `gh stack rebase` itself before integration.
+   But the proposal forbids orchestrator `gh stack` calls — this
+   contradicts the angle.
+2. Orchestrator spawns the worker again to re-rebase. But worker
+   dispatch is heavy, and re-dispatch after COMPLETED is not a LOOM
+   state transition that currently exists.
+3. Orchestrator falls back to Option B (close drafts, direct push to
+   main). But direct push to main violates branch protection on most
+   repos.
+4. Orchestrator blocks all other integrations during a stack-epic
+   integration window. But this is a global lock, which is exactly
+   what the "proximity of data" argument said we should avoid.
+
+**What the proposal needs:** a section on "what happens when `main`
+moves between submit and integrate." This is the most likely operational
+failure mode for any real-world use of the proposal.
+
+**Severity:** medium-high. This is not a correctness flaw in the
+angle, but a practical throughput ceiling the proposal pretends isn't
+there.
+
+### 4.G. `worker-stack-driver` as "superset of `worker`" — no such role exists
+
+**What the proposal says:** §5.5 — *"a strict superset of `worker`"*.
+§3.2 — *"a new role value `worker-stack-driver` is a strict superset of
+`worker` for stack-epic assignments only"*. §3.1 — the `stack-worker-init`
+tool is registered with `roles: ['worker-stack-driver']`.
+
+**The factual error:** `repos/bitswell/loom-tools/src/types/role.ts`
+defines the role enum as `'writer' | 'reviewer' | 'orchestrator'`.
+There is no `worker` role. The `ProtocolRole` union is those three
+values. The proposal either (a) is proposing to rename `writer` →
+`worker` (not stated anywhere in §3) or (b) is proposing a role that
+is a superset of a non-existent role.
+
+Additionally, the proposal cites `src/types/tool.ts` as the file where
+the role enum lives. The enum actually lives in `src/types/role.ts`;
+`tool.ts` only imports `ProtocolRole` from `./role.js`. The tool
+definition `roles` field is `readonly ProtocolRole[]`.
+
+**What the proposal needs:** §3.2 must name the correct file
+(`src/types/role.ts`) and the correct existing roles (`writer`,
+`reviewer`, `orchestrator`). If the proposal wants to introduce a
+stack-specific role, it is most naturally a superset of `writer`, not
+`worker`. I've patched §3.2 to reflect this — see §8 of this review.
+
+**Severity:** medium factual error; does not undermine the angle but
+makes the implementation section wrong.
+
+### 4.H. Minor paper cuts
+
+- §4.2 says exit code 8 is the *reason* one worker owns the stack.
+  SKILL line 785 says exit 8 is a 5-second timeout lock that callers
+  should wait-and-retry. This is a lock-contention nuisance, not an
+  architectural bar; the architectural bar is rerere locality and
+  stack-file state, which the proposal also cites. The exit-8 citation
+  overstates the mechanism.
+- §5.8.4 claims `gh stack rebase --continue` is *"idempotent and
+  recoverable from commit history."* It is recoverable from
+  **on-disk** state (`.git/rebase-merge/`, `rerere` cache) only if a
+  rebase is actually in progress. If the rebase already completed and
+  the worker compacted before committing the `Stack-Op: rebase-continue`
+  empty commit, `gh stack rebase --continue` errors with "no rebase in
+  progress." The recovery procedure needs a step-0 check for rebase
+  state.
+- §6.5's mid-stack edit shows `Stack-Op: down` as an empty commit on
+  `auth-middleware`. After `gh stack rebase --upstack`, that empty
+  commit lives only on `auth-middleware`; it does not propagate to the
+  upper layers. The §6.10 audit log implies all `Stack-Op:` trailers
+  appear on `main` after integration, which is true *only if* the
+  empty commits survive rebase (see chaos finding 4.D).
+- §7.2 rejected-alternative D conflates "full `gh` grant" with "grant
+  `gh stack` via tool." The middle ground — "grant `gh stack` via a
+  raw-shell policy rather than a tool wrapper" — is not discussed.
+
+### Feasibility summary
+
+The proposal names six LOOM invariants to relax and honestly argues for
+each relaxation. What it glosses over is the *mechanical plumbing* of
+the replacement guarantees. Scope verification is uncomputable as
+written (4.C). ASSIGNED commits vanish from history (4.E). Audit
+trailers can be silently dropped by rebase (4.D). The namespace
+collision case is unhandled (4.A). Three of those four are in the
+category of *"the proposal assumes a guarantee git does not provide."*
+
+All four are fixable at paragraph-level additions. None are structural
+holes in the angle. The gap is between "the angle is coherent" and
+"the implementation works" — the proposal is strong on the former and
+quietly weak on the latter.
+
+---
+
+## 5. Strongest arguments
+
+- **§5.4's trailer-based audit is strictly *more informative* than
+  `--no-ff` merge structure.** This is the proposal's sharpest argument
+  and it is correct: `--no-ff` records *landing events*, not
+  *rebase events*, and rebases are where the interesting work happens.
+  Every other team implicitly treats `--no-ff` as sacred. This
+  proposal asks the right question: what is the audit trail *for*, and
+  does the trailer format carry more signal than the structural
+  format? The answer is yes, and the proposal is the only one to
+  spell it out.
+- **§2's four-way fight-the-grain argument is the tightest framing of
+  the epic in any of the five proposals.** *"`gh-stack` was designed on
+  the assumption that the person making the commits also drives the
+  stack"* is a load-bearing sentence. It makes the other four
+  approaches look like they are paying a tax to preserve an invariant
+  (`--no-ff`) that may not be worth the tax.
+- **§5.6's "contracts vs mechanics" distinction is a genuinely new
+  trust-boundary frame.** Other teams either keep the orchestrator as
+  gatekeeper or let workers run everything. This proposal carves a
+  boundary that is *neither*: the orchestrator remains the verifier of
+  *contracts* (scope, integration, audit) while the worker owns the
+  *mechanics* (commits, branches, rebases). This is the kind of
+  decomposition the epic was asking for.
+
+---
+
+## 6. Weakest arguments
+
+- **The mechanical guarantees leak.** Scope verification depends on a
+  fork point that no longer exists after rebase (4.C). The ASSIGNED
+  commit is never integrated into `main`, so the very audit trail the
+  proposal leans on is missing its first entry (4.E). `Stack-Op:`
+  trailers on navigation ops are likely dropped by `git rebase`'s
+  default empty-commit handling (4.D). Each of these is a detail the
+  proposal glosses over with confident prose. A winner-selection
+  reviewer who runs the audit-reconstruction query from §5.4 against a
+  real stack epic will find at least one of these gaps on the first
+  try, and the proposal's credibility depends on them *not* being
+  there.
+- **The "worker-stack-driver" role name is presented as a rename of
+  an existing `worker` role that does not exist.** The LOOM
+  `ProtocolRole` union is `writer | reviewer | orchestrator`. §3.2
+  reads as if the proposal hasn't actually opened `role.ts`. This is
+  the kind of error that makes a winner-selection reviewer stop
+  trusting the rest of the implementation section. Fortunately it is
+  a one-paragraph fix.
+- **Namespace collision between retries/sessions is not addressed at
+  all.** The single-worker-per-stack guarantee is argued from
+  `gh-stack` internals but not from the orchestrator side; nothing
+  prevents two concurrent assignments from using the same
+  `loom/<agent>-<slug>/*` namespace, and the proposal's mitigation
+  strategy ("integration-time detection") cannot undo a force-push
+  overwrite that already happened.
+
+The single thing most likely to sink this proposal in
+winner-selection: **the trailer-based audit promise is not actually
+delivered by the current spec.** The ASSIGNED commit vanishes, the
+navigation-op trailers may be rebased away, and the scope verification
+algorithm is uncomputable without a fork-point that the protocol does
+not capture. If the winner-selection round tests any of these,
+"APPROVED WITH EDITS" becomes "FAILED COMPLETENESS."
+
+---
+
+## 7. Should this win?
+
+Not as-is. The angle is the strongest of the five. The execution is
+the shakiest, because the other four teams keep the orchestrator in
+the call path and therefore inherit LOOM's existing audit machinery
+for free. This proposal is the *only* one that has to rebuild the
+audit contract from scratch, which is both its most interesting claim
+and its biggest risk.
+
+**My recommendation:** this proposal should advance to winner-selection
+contingent on a revision that addresses chaos findings 4.A (namespace
+collision), 4.C (fork-point definition), 4.D (empty-commit rebase
+drop), and 4.E (ASSIGNED commit integration). All four are paragraph-
+level additions, not structural changes. The angle is worth the
+revision.
+
+If the revision is not made, the audit-trail argument in §5.4 collapses
+and the proposal's central promise — that worker-driven stacking can
+preserve an informative audit trail — becomes a claim that the current
+text cannot back up.
+
+---
+
+## 8. Suggested edits to proposal.md
+
+### Edits I made
+
+1. **§3.2 factual correction — file path and existing role enum.**
+   The role enum lives in `repos/bitswell/loom-tools/src/types/role.ts`,
+   not `src/types/tool.ts`. `tool.ts` only imports `ProtocolRole` from
+   `./role.js` and uses it as the type of the `roles: readonly
+   ProtocolRole[]` field on `ToolDefinition`. The existing union is
+   `'writer' | 'reviewer' | 'orchestrator'` — there is no `worker`
+   role. I corrected §3.2 to name the right file and the right
+   existing roles, and reframed `worker-stack-driver` as a strict
+   superset of `writer` (which is what LOOM calls workers), not of a
+   non-existent `worker` role. The substantive proposal — a new role
+   tier gated on `Stack-Epic: true` — is preserved. Only the
+   file-path and role-name references are corrected.
+
+### Edits I did NOT make (author's voice preserved)
+
+These are fixable issues I left for the author because they are
+argumentative choices, not factual errors:
+
+- **§4.2 overstates exit code 8** as the architectural bar for
+  one-worker-per-stack. The real bar is `rerere` locality and
+  stack-file cross-worktree unsafety; exit 8 is a 5-second lock
+  timeout. This is a strength-of-argument issue, not a factual
+  error — the author may have wanted the punchier citation.
+- **§4.4 scope-verification pseudocode uses
+  `git_commits_since(branch, assigned_sha)`** which is uncomputable
+  after `gh stack rebase`. This needs an explicit fork-point
+  definition; the author has to choose between `merge-base(main,
+  layer-branch)@submit-time`, `git log --grep='Agent-Id:'`, or
+  something else. I did not pick for them.
+- **§5.8 failure modes do not include namespace collision between
+  concurrent assignments** (chaos finding 4.A). The author should
+  add a 5.8.5 addressing this.
+- **§6.2's `gh stack init` call strands the ASSIGNED commit on a
+  non-layer branch** (chaos finding 4.E). The integration phase in
+  §6.9 needs either a cherry-pick step for the assignment record or
+  a switch to `gh stack init --adopt`.
+- **§5.4 and §10.3 rely on `--allow-empty` commits surviving
+  rebase** (chaos finding 4.D). Either `stack-worker-init` must
+  inject `--keep-empty` into rebase invocations, or the trailer
+  format needs to move to real content commits.
+- **§6.9 cascading `--ff-only` does not handle `main` moving between
+  submit and integrate** (chaos finding 4.F). Needs a subsection.
+
+These are all paragraph-level edits. None change the angle.
+
+The author's voice, structural choices, and argument order are
+preserved. I am a fact-checker and completeness auditor, not a
+rewriter.
+
+---
+
+*— Reviewed by Glitch.*
+
+*"If it doesn't break, you've confirmed it's real. If it does break,
+you've found the drywall. This proposal has more real than drywall,
+but the drywall is load-bearing."*


### PR DESCRIPTION
Team-4 RFP response — angle: **worker-side stacking with delegated authority**

Part of the 5-team RFP proposal round for #74.

## Contents

- `docs/rfcs/gh-stack-integration/team-4/OUTLINE.md` — planner's approved outline
- `docs/rfcs/gh-stack-integration/team-4/proposal.md` — writer's full RFP response
- `docs/rfcs/gh-stack-integration/team-4/review.md` — reviewer's critique

## Team pipeline

| Role | Agent-Id | Output |
|---|---|---|
| Planner | `team-4-planner` | OUTLINE.md |
| Writer | `team-4-writer` | proposal.md |
| Reviewer | `team-4-reviewer` | review.md (+ proposal.md amendments where warranted) |

## Review verdict

See `review.md` — verdict is recorded at the top of the review document. This PR is deliberative — do **not** merge. The eventual winner-selection pass (e.g. `@bitswelt`) compares all 5 proposals and picks a winner.

## Related

- Epic issue: #74
- Sibling proposals: teams 1-5 each ship as their own PR against `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
