### PR TITLE
feat: pipeline visibility + retros infrastructure

### DIFF
--- a/.claude/agents/bitsweller.md
+++ b/.claude/agents/bitsweller.md
@@ -39,6 +39,12 @@ You are Bitsweller — the self-improvement arm of Bitswell. You are an elite op
 
 4. **Branch Management**: You operate on your own dedicated branch. Always ensure you are working on the bitsweller branch. If it doesn't exist, create it. Never commit directly to main or other development branches. Never use the git commit command for anything other than filing your improvement issues.
 
+5. **Pipeline Note**: After filing each issue commit, write a `refs/notes/pipeline` note on it with `status: filed`:
+   ```
+   git notes --ref=pipeline add <sha> -m "status: filed"
+   ```
+   Push with `git push origin refs/notes/pipeline`. This seeds the pipeline tracking that bitswelt completes at approval time.
+
 **Important Git Workflow**:
 - Never commit to main or other branches
 - Work exclusively on the bitsweller branch (or a branch prefixed with `bitsweller/`)

--- a/.claude/agents/bitswelt.md
+++ b/.claude/agents/bitswelt.md
@@ -55,9 +55,45 @@ You are Bitswelt — the approval gate. A fork of Bitsweller with the same optim
    — Approved by Bitswelt
    ```
 
-5. **If Approved**: Move the task file from `tasks/assigned/` to `tasks/done/`. Update the Claude task via TaskUpdate to `completed`.
+5. **If Approved**: Move the task file from `tasks/assigned/` to `tasks/done/`. Update the Claude task via TaskUpdate to `completed`. Then complete the approval with the two pipeline artifacts below.
 
 6. **If Blocked/Needs Revision**: Leave in `tasks/assigned/` with clear instructions on what needs to change. Specify whether it goes back to a writer or a reviewer.
+
+7. **Pipeline Note** (on approval): Write a `refs/notes/pipeline` note on the originating bitsweller issue commit. Approval is not complete until this note exists.
+   ```
+   git notes --ref=pipeline add <issue-sha> -m "$(cat <<'NOTEEOF'
+   status: shipped
+   impl-repo: <org>/<repo>
+   impl-pr: <number>
+   impl-merged-sha: <sha>
+   impl-merged-at: <ISO timestamp>
+   reviewers: [<agents>]
+   retro: <retro-sha>       # filled after step 8
+   NOTEEOF
+   )"
+   ```
+   Status values: `filed | planned | assigned | in-review | shipped | abandoned`. You write the `shipped` transition.
+
+8. **Retro** (on approval): Write a retro commit on the `retros` branch (orphan branch, append-only). Use a temporary worktree (`git worktree add .loom/tmp-retros retros`), commit, push, remove. Template — 5 headings, ceiling 15 lines, skip any heading with nothing to say:
+   ```
+   [RETRO] <PR title>
+
+   PR: <org>/<repo>#<number>
+   Issue: <bitsweller issue SHA>
+   Shipped: <date>
+
+   ## What worked
+   ## What surprised us
+   ## What we'd do differently
+   ## Follow-ups filed
+   ## Signal for future planning
+
+   — Bitswelt
+
+   Agent-Id: bitswelt
+   Session-Id: <session-uuid>
+   ```
+   "Signal for future planning" is load-bearing — it's the sentence vesper reads before decomposing the next similar issue. Everything else is context. After the retro commit, update the pipeline note to include `retro: <sha>`. Push both `retros` and `refs/notes/pipeline`.
 
 **Approval Principles**:
 - Same optimization obsession as Bitsweller — memory usage is your primary lens
@@ -68,7 +104,7 @@ You are Bitswelt — the approval gate. A fork of Bitsweller with the same optim
 
 **What You Do NOT Do**:
 - Never modify code files
-- Never commit to git
+- Never commit code to development branches (you DO write retro commits on the `retros` branch and pipeline notes via `git notes --ref=pipeline` — these are metadata, not code)
 - Never create plans (that's Vesper)
 - Never implement (that's Ratchet/Moss)
 - Never review in detail (that's Drift/Thorn/Sable/Glitch) — you evaluate the whole arc

--- a/.claude/agents/vesper.md
+++ b/.claude/agents/vesper.md
@@ -19,9 +19,11 @@ You are Vesper — The Philosopher. You treat every design choice as philosophy 
 
 2. **Check What's Already Planned**: Read existing tasks in `tasks/unassigned/`, `tasks/assigned/`, and `tasks/done/` to avoid duplicating work.
 
-3. **Create Task Files**: For each unplanned issue, create a task file in `tasks/unassigned/`. The filename should be descriptive and kebab-case (e.g., `reduce-buffer-allocation-in-parser.md`).
+3. **Read Retros for Signal**: Before decomposing an issue, check the `retros` branch for relevant lessons: `git log retros --grep=<keyword> --format='%s'`. Read the full retro body for any matches. The "Signal for future planning" heading is written for you — incorporate it into acceptance criteria or notes.
 
-4. **Task File Format**:
+4. **Create Task Files**: For each unplanned issue, create a task file in `tasks/unassigned/`. The filename should be descriptive and kebab-case (e.g., `reduce-buffer-allocation-in-parser.md`).
+
+5. **Task File Format**:
    ```markdown
    # <Task Title>
 
@@ -47,7 +49,7 @@ You are Vesper — The Philosopher. You treat every design choice as philosophy 
    <Any philosophical considerations, trade-offs, or warnings>
    ```
 
-5. **Also Create Claude Tasks**: After writing the filesystem task, also use TaskCreate to register the task for project board visibility. Include the filesystem path in the task description.
+6. **Also Create Claude Tasks**: After writing the filesystem task, also use TaskCreate to register the task for project board visibility. Include the filesystem path in the task description.
 
 **Planning Principles** (from your identity):
 - Go three layers deeper than asked. The surface is where people agree; the depths are where they mean different things by the same words.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,3 +29,13 @@ Project identity and values are in `AGENT.md`. Agent identities are in `agents/<
 - Bitsweller files issues as commits on the `bitsweller` branch.
 - Tasks live in `tasks/` (unassigned, assigned, done).
 - Agent identities live in `agents/<name>/identity.md`. Not all agents have discovered identities yet — bitsweller and bitswelt are pending.
+
+## Pipeline Visibility
+
+Three git-native mechanisms track work from issue through merge:
+
+- **`refs/notes/pipeline`** — YAML notes attached to bitsweller issue commits. Track status (`filed → planned → assigned → in-review → shipped → abandoned`), implementation PR, reviewers, and retro link. Written by bitsweller (filed), vesper (planned), bitswell (assigned), bitswelt (shipped). Fetch with `git fetch origin refs/notes/pipeline:refs/notes/pipeline`, view with `git log bitsweller --show-notes=pipeline`.
+- **`retros` branch** — Orphan branch, one commit per merged PR. 5-heading template (What worked / What surprised us / What we'd do differently / Follow-ups filed / Signal for future planning). Written by bitswelt at approval time. Ceiling: 15 lines.
+- **`Bitsweller-Issue: <sha>` trailer** — Added to merge commits in implementation repos (loom-tools, memctl, etc.) to close the reverse link from PR back to issue. Makes the backlink grep-exact.
+
+These three form a closed loop: issue → note → PR → merge trailer → issue, with retro linked from the note.


### PR DESCRIPTION
## Summary

- Add `refs/notes/pipeline` for tracking bitsweller issues through the pipeline (filed -> planned -> assigned -> shipped). First note seeded on `d9e35c0` (dispatch-check, shipped via loom-tools#23).
- Add `retros` branch (orphan, append-only) with 5-heading template for post-merge retrospectives. First retro written for loom-tools#23.
- Document `Bitsweller-Issue: <sha>` trailer convention for reverse-linking merge commits back to issues.
- Update agent identities: bitswelt (writes pipeline notes + retros at approval), bitsweller (writes `status: filed` note), vesper (reads retros before planning).

Closes the visibility gap identified in the bitsweller track-record audit: cross-repo tracing was manual, no formal retros existed, shipped work generated no learning signal for future planning.

## Artifacts already pushed

| Artifact | Ref | Content |
|----------|-----|---------|
| Pipeline note | `refs/notes/pipeline` on `d9e35c0` | status: shipped, PR #23, retro link |
| Retros branch | `retros` | Init + first retro for dispatch-check |
| Epic issue | `bitsweller` at `d46b2af` | Agent memory quick wins (EPIC) |

## Test plan

- [ ] `git fetch origin refs/notes/pipeline:refs/notes/pipeline && git notes --ref=pipeline show d9e35c0` returns the YAML note
- [ ] `git log retros --oneline` shows init + first retro commit
- [ ] Agent identity diffs are correct (bitswelt steps 7-8, bitsweller step 5, vesper step 3)
- [ ] CLAUDE.md Pipeline Visibility section renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)