### PR TITLE
feat(projects): plant team/project manifest foundation

### DIFF
--- a/projects/README.md
+++ b/projects/README.md
@@ -1,0 +1,25 @@
+# projects/
+
+A **project** is a focused slice of work across some subset of the repos in this org — with its own GitHub Project (board) and its own agent roster. One manifest per project, committed to `main`. Because manifests are ordinary tracked YAML, every scope change, board link, and roster shift is an ordinary commit — "project info in git history."
+
+## Schema
+
+Each `projects/<slug>.yaml` has:
+
+- **`slug`** — short, lowercase, dash-separated. Matches the filename. Used in worktree paths and labels.
+- **`name`** — human-readable display name.
+- **`description`** — what the project is and why it exists. Free-form prose.
+- **`github_project`** — URL of the GitHub Project (board) for this slice, or `null` if not yet created.
+- **`repos`** — list of repo paths (relative to this tree, e.g. `repos/bitswell/loom-tools`) that fall inside the project's scope. May be empty for greenfield projects.
+- **`agents`** — roster of agent slugs authorized to act on this project.
+
+## Current projects
+
+- **`bitswell-core`** — the bitswell agent system itself: identity discovery, LOOM protocol, pipeline visibility, and supporting tools.
+- **`ember`** — imminent Hetzner pilot-light orchestrator that summons ephemeral RunPod GPU workers over a private Tailscale mesh.
+
+## Status
+
+No agent reads these manifests yet. This is **Step 1** of the team/project abstraction — a tree-only foundation. Subsequent bitsweller issues will wire consumers (worktree path scoping, PR-as-issue GHA, task-branch model).
+
+See `CLAUDE.md` § "Pipeline Visibility" for how projects will plug into the existing `refs/notes/pipeline` / retros / merge-trailer loop.

--- a/projects/bitswell-core.yaml
+++ b/projects/bitswell-core.yaml
@@ -1,0 +1,24 @@
+slug: bitswell-core
+name: Bitswell Core
+description: |
+  The bitswell agent system itself — identity discovery, LOOM protocol,
+  pipeline visibility, and the supporting tools (loom-tools, loom-plugin,
+  loom-site, memctl).
+github_project: null  # TODO: link when a board is created
+repos:
+  - repos/bitswell/loom-tools
+  - repos/bitswell/loom-plugin
+  - repos/bitswell/loom-site
+  - repos/bitswell/memctl
+agents:
+  - bitswell
+  - shuttle
+  - bitsweller
+  - vesper
+  - ratchet
+  - moss
+  - drift
+  - sable
+  - thorn
+  - glitch
+  - bitswelt

--- a/projects/ember.yaml
+++ b/projects/ember.yaml
@@ -1,0 +1,21 @@
+slug: ember
+name: Ember
+description: |
+  Small always-on Hetzner orchestrator (the pilot light) that summons
+  ephemeral RunPod GPU workers on demand, tied together with a private
+  Tailscale mesh. €4/mo ember fans into flame when compute is needed,
+  returns to ember when idle.
+github_project: null  # TODO: link when a board is created
+repos: []  # Greenfield — repos scaffold as the project develops
+agents:
+  - bitswell
+  - shuttle
+  - bitsweller
+  - vesper
+  - ratchet
+  - moss
+  - drift
+  - sable
+  - thorn
+  - glitch
+  - bitswelt


### PR DESCRIPTION
## Summary

Step 1 of the team/project abstraction plan: tree-only foundation.

Adds `projects/` with three files — nothing else:

- `projects/README.md` — schema documentation + current project roster
- `projects/bitswell-core.yaml` — the current implicit project (bitswell agent system + supporting tools)
- `projects/ember.yaml` — imminent Hetzner/RunPod pilot-light orchestrator (greenfield, no repos yet)

## Non-goals

- **No agent behavior changes.** No edits to `.claude/agents/*.md`, `CLAUDE.md`, `startup.sh`, `scripts/hooks/*`, or any submodule.
- **No consumers yet.** Subsequent bitsweller issues will wire worktree path scoping, PR-as-issue GHA, and the task-branch model to read these manifests.

## Plan

Full plan: `~/.claude/plans/upon-reflection-it-seems-encapsulated-rain.md` (Step 1 of 6).

## Verification

- `ls projects/` — exactly `README.md`, `bitswell-core.yaml`, `ember.yaml`
- `wc -l projects/README.md` — 25 lines (< 40 line cap)
- Both YAML files parse clean (`python3 -c 'import yaml; yaml.safe_load(open(p))'`)
- `git diff --stat origin/main...HEAD` — 3 files changed, 70 insertions, nothing else touched

— Orchestrated by Shuttle