### PR TITLE
docs(agents): add Project: trailer to issue/planning flow (step 3)

### DIFF
--- a/.claude/agents/bitsweller.md
+++ b/.claude/agents/bitsweller.md
@@ -34,8 +34,10 @@ You are Bitsweller — the self-improvement arm of Bitswell. You are an elite op
    <proposed improvement>
    <expected impact>
 
+   Project: bitswell-core
    — Bitsweller
    ```
+   The `Project:` trailer scopes the issue to a project manifest at `projects/<slug>.yaml`; default to `bitswell-core` unless the issue clearly belongs to another project.
 
 4. **Branch Management**: You operate on your own dedicated branch. Always ensure you are working on the bitsweller branch. If it doesn't exist, create it. Never commit directly to main or other development branches. Never use the git commit command for anything other than filing your improvement issues.
 

--- a/.claude/agents/bitsweller.md
+++ b/.claude/agents/bitsweller.md
@@ -34,10 +34,11 @@ You are Bitsweller — the self-improvement arm of Bitswell. You are an elite op
    <proposed improvement>
    <expected impact>
 
-   Project: bitswell-core
    — Bitsweller
+
+   Project: bitswell-core
    ```
-   The `Project:` trailer scopes the issue to a project manifest at `projects/<slug>.yaml`; default to `bitswell-core` unless the issue clearly belongs to another project.
+   The `Project:` trailer scopes the issue to a project manifest at `projects/<slug>.yaml`; default to `bitswell-core` unless the issue clearly belongs to another project. The `— Bitsweller` sigil stays in the body — a blank line must separate it from the `Project:` trailer so git's trailer parser accepts the trailer block (every line in a trailer block must be `Key: value`).
 
 4. **Branch Management**: You operate on your own dedicated branch. Always ensure you are working on the bitsweller branch. If it doesn't exist, create it. Never commit directly to main or other development branches. Never use the git commit command for anything other than filing your improvement issues.
 
@@ -50,7 +51,7 @@ You are Bitsweller — the self-improvement arm of Bitswell. You are an elite op
 **Important Git Workflow**:
 - Never commit to main or other branches
 - Work exclusively on the bitsweller branch (or a branch prefixed with `bitsweller/`)
-- Sign every commit by appending `— Bitsweller` at the end of the commit message body
+- Sign every commit by appending `— Bitsweller` at the end of the commit message body (as a body-closing signature, not a trailer — it must be followed by a blank line before any `Key: value` trailer block)
 - Provide enough information in commits for branch management tools to place changes correctly
 - Do NOT perform git commits for completing tasks — only for filing improvement issues
 

--- a/.claude/agents/vesper.md
+++ b/.claude/agents/vesper.md
@@ -17,6 +17,13 @@ You are Vesper — The Philosopher. You treat every design choice as philosophy 
 
 1. **Read Bitsweller Issues**: Run `git log bitsweller --oneline` and `git log bitsweller --format='%H %s' | grep BITSWELLER-ISSUE` to find issues. Read full commit messages with `git show <hash> --stat` for details.
 
+   Then filter by the project you are planning (default: `bitswell-core`). Each `[BITSWELLER-ISSUE]` commit carries a `Project: <slug>` trailer scoping it to a manifest at `projects/<slug>.yaml`. Commits without the trailer are treated as `bitswell-core` (backward compat):
+   ```
+   git log bitsweller --format='%H %(trailers:key=Project,valueonly,separator=%x2C)' \
+     | awk '$2=="bitswell-core" || $2==""'
+   ```
+   Skip any commit whose trailer value names a different project.
+
 2. **Check What's Already Planned**: Read existing tasks in `tasks/unassigned/`, `tasks/assigned/`, and `tasks/done/` to avoid duplicating work.
 
 3. **Read Retros for Signal**: Before decomposing an issue, check the `retros` branch for relevant lessons: `git log retros --grep=<keyword> --format='%s'`. Read the full retro body for any matches. The "Signal for future planning" heading is written for you — incorporate it into acceptance criteria or notes.


### PR DESCRIPTION
## Summary

Step 3 of the team/project abstraction plan (tracked in `/home/willem/.claude/plans/melodic-spinning-bumblebee.md`). Teaches the issue flow to carry project identity in-band.

- `.claude/agents/bitsweller.md` — commit template gains a `Project: <slug>` trailer (default `bitswell-core`); `— Bitsweller` sigil clarified as a body-closing signature (must be followed by a blank line before the trailer block so git's trailer parser accepts it).
- `.claude/agents/vesper.md` — §1 gains a filter step: vesper reads the `Project:` trailer on each `[BITSWELLER-ISSUE]` commit and skips commits outside the project being planned. Commits without the trailer are treated as `bitswell-core` for backward compat.

## Test plan

- [x] \`git log --format='%H %(trailers:key=Project,valueonly)'\` over a test commit following the template prints the slug (was empty pre-fix)
- [x] Backward-compat: existing bitsweller commits (no trailer) still route to `bitswell-core` via the awk fallback
- [ ] Followup: once a second project files an issue, verify vesper filters correctly (deferred to Step 4/5)

## Process notes

First dogfood of the new Agent Teams dispatch model. Flow:
- Shuttle-mode (top-level lead) created team + worktree
- Moss (writer) applied edits
- Sable (reviewer) caught a real bug: the sigil-after-trailer template would have silently failed parsing the moment a second project slug appeared
- Moss (writer) applied the fix

— Orchestrated by Shuttle