### PR TITLE
feat(ci): mirror [BITSWELLER-ISSUE] commits to draft PRs (step 4)

### DIFF
--- a/.github/workflows/bitsweller-issue-to-pr.yml
+++ b/.github/workflows/bitsweller-issue-to-pr.yml
@@ -1,0 +1,198 @@
+# Bitsweller Issue → Draft PR (dual-write mirror)
+#
+# Part of the "PR-as-issue" migration: every [BITSWELLER-ISSUE] commit on the
+# `bitsweller` branch is mirrored as a draft PR against `main`, so issues
+# become browsable in the regular GitHub PR UI while the bitsweller branch
+# remains authoritative. This is the dual-write phase — both projections
+# exist; consumers can read either.
+#
+# Idempotency: each mirrored PR carries a `Source-Issue-Sha: <sha>` line in
+# its body. Before opening a PR we search for that sentinel across all PR
+# states; if a match exists we skip. Re-running the workflow (via push or
+# workflow_dispatch) over already-mirrored commits is a safe no-op.
+#
+# Notes: on success we seed `refs/notes/pipeline` on the source bitsweller
+# commit with `status: filed`, `issue-pr: <num>`, `project: <slug>`, merged
+# with any keys the note already had (so downstream writers like bitswelt
+# don't get clobbered).
+
+name: Bitsweller Issue to PR
+
+on:
+  push:
+    branches: [bitsweller]
+  workflow_dispatch:
+    inputs:
+      backfill_depth:
+        description: 'How many recent bitsweller commits to consider (workflow_dispatch only)'
+        required: false
+        default: '1'
+        type: string
+      dry_run:
+        description: 'Log actions without opening PRs or writing notes'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: bitsweller-issue-to-pr
+  cancel-in-progress: false
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout main with full history
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Fetch bitsweller and pipeline notes
+        run: |
+          set -euo pipefail
+          git fetch origin bitsweller main 'refs/notes/pipeline:refs/notes/pipeline' 2>/dev/null || true
+
+      - name: Configure git identity
+        run: |
+          set -euo pipefail
+          git config user.email "bitsweller-issue-to-pr@users.noreply.github.com"
+          git config user.name  "bitsweller-issue-to-pr[bot]"
+
+      - name: Mirror [BITSWELLER-ISSUE] commits to draft PRs
+        id: mirror
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_BEFORE: ${{ github.event.before }}
+          EVENT_AFTER: ${{ github.event.after }}
+          BACKFILL_DEPTH: ${{ inputs.backfill_depth || '1' }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+          REPO: ${{ github.repository }}
+          SERVER_URL: ${{ github.server_url }}
+        run: |
+          set -euo pipefail
+
+          zero=0000000000000000000000000000000000000000
+          shas=""
+
+          if [ "$EVENT_NAME" = "push" ]; then
+            if [ "${EVENT_AFTER:-$zero}" = "$zero" ]; then
+              echo "Branch deleted (after=$zero); nothing to mirror."
+              echo "created=0" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            if [ -z "${EVENT_BEFORE:-}" ] || [ "$EVENT_BEFORE" = "$zero" ]; then
+              # First push or force-push — only mirror the tip commit.
+              shas=$(git log --format='%H' -n 1 "$EVENT_AFTER" 2>/dev/null || true)
+            else
+              shas=$(git log --format='%H' --reverse "${EVENT_BEFORE}..${EVENT_AFTER}" 2>/dev/null || true)
+            fi
+          else
+            shas=$(git log origin/bitsweller --format='%H' -n "$BACKFILL_DEPTH" 2>/dev/null | tac || true)
+          fi
+
+          created=0
+          if [ -z "${shas:-}" ]; then
+            echo "No commits to process."
+            echo "created=$created" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Processing $(printf '%s\n' "$shas" | wc -l) commit(s)."
+
+          while IFS= read -r sha; do
+            [ -z "$sha" ] && continue
+
+            subject=$(git log -1 --format='%s' "$sha")
+            case "$subject" in
+              '[BITSWELLER-ISSUE]'*) ;;
+              *) echo "skip $sha: subject does not start with [BITSWELLER-ISSUE]"; continue ;;
+            esac
+
+            body=$(git log -1 --format='%b' "$sha")
+            project=$(git log -1 --format='%(trailers:key=Project,valueonly)' "$sha" | head -n1 | xargs || true)
+            if [ -z "$project" ]; then
+              project="bitswell-core"
+            fi
+
+            existing_pr=$(gh pr list --state all --search "Source-Issue-Sha: $sha" --json number --limit 1 -q '.[0].number' 2>/dev/null || true)
+            if [ -n "$existing_pr" ]; then
+              echo "skip $sha: PR #$existing_pr already mirrors this commit"
+              continue
+            fi
+
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "dry-run: would create PR for $sha (project=$project) — \"$subject\""
+              continue
+            fi
+
+            short_sha=${sha:0:12}
+            branch="issue/${short_sha}"
+
+            if git ls-remote --heads origin "$branch" | grep -q .; then
+              echo "skip $sha: remote branch $branch already exists"
+              continue
+            fi
+
+            commit_url="${SERVER_URL}/${REPO}/commit/${sha}"
+
+            git checkout -B "$branch" origin/main
+
+            commit_msg=$(printf '%s\n\n%s\n\nSource-Issue-Sha: %s\nProject: %s\n' \
+              "$subject" "$body" "$sha" "$project")
+            git commit --allow-empty -m "$commit_msg"
+            git push origin "$branch"
+
+            pr_body=$(printf '%s\n\n---\n_Filed as `[BITSWELLER-ISSUE]` commit [`%s`](%s) on the `bitsweller` branch._\n\nSource-Issue-Sha: `%s`\nProject: `%s`\n' \
+              "$body" "$short_sha" "$commit_url" "$sha" "$project")
+
+            pr_url=$(gh pr create --draft --base main --head "$branch" \
+              --title "$subject" --body "$pr_body")
+            pr_num="${pr_url##*/}"
+            echo "created PR #$pr_num for $sha"
+
+            gh label create "project:$project" --color 0052cc \
+              --description "Mirrored from bitsweller project: $project" 2>/dev/null || true
+            gh pr edit "$pr_num" --add-label "project:$project" 2>/dev/null || true
+
+            existing_note=$(git notes --ref=pipeline show "$sha" 2>/dev/null || true)
+            filtered_note=""
+            if [ -n "$existing_note" ]; then
+              filtered_note=$(printf '%s\n' "$existing_note" | grep -vE '^(status|issue-pr|project):[[:space:]]*' || true)
+            fi
+            new_note=$(
+              { [ -n "$filtered_note" ] && printf '%s\n' "$filtered_note"
+                printf 'status: filed\nissue-pr: %s\nproject: %s\n' "$pr_num" "$project"
+              }
+            )
+            printf '%s' "$new_note" | git notes --ref=pipeline add -f -F - "$sha"
+
+            created=$((created + 1))
+          done <<< "$shas"
+
+          if [ "$DRY_RUN" != "true" ] && [ "$created" -gt 0 ]; then
+            git push origin refs/notes/pipeline 2>/dev/null || true
+          fi
+
+          echo "created=$created" >> "$GITHUB_OUTPUT"
+          echo "Mirrored $created new PR(s)."
+
+      - name: Write job summary
+        if: always()
+        run: |
+          set -euo pipefail
+          {
+            echo "### Bitsweller issue mirror"
+            echo ""
+            echo "- Event: \`${{ github.event_name }}\`"
+            echo "- Dry run: \`${{ inputs.dry_run || 'false' }}\`"
+            echo "- New PRs mirrored: \`${{ steps.mirror.outputs.created || '0' }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/bitsweller-issue-to-pr.yml
+++ b/.github/workflows/bitsweller-issue-to-pr.yml
@@ -100,6 +100,8 @@ jobs:
           fi
 
           created=0
+          staged_shas=()
+          staged_contents=()
           if [ -z "${shas:-}" ]; then
             echo "No commits to process."
             echo "created=$created" >> "$GITHUB_OUTPUT"
@@ -123,7 +125,9 @@ jobs:
               project="bitswell-core"
             fi
 
-            existing_pr=$(gh pr list --state all --search "Source-Issue-Sha: $sha" --json number --limit 1 -q '.[0].number' 2>/dev/null || true)
+            # Let set -e propagate: a failed idempotency check MUST abort, not
+            # silently proceed to create a duplicate PR.
+            existing_pr=$(gh pr list --state all --search "Source-Issue-Sha: $sha" --json number --limit 1 -q '.[0].number')
             if [ -n "$existing_pr" ]; then
               echo "skip $sha: PR #$existing_pr already mirrors this commit"
               continue
@@ -163,23 +167,57 @@ jobs:
               --description "Mirrored from bitsweller project: $project" 2>/dev/null || true
             gh pr edit "$pr_num" --add-label "project:$project" 2>/dev/null || true
 
-            existing_note=$(git notes --ref=pipeline show "$sha" 2>/dev/null || true)
-            filtered_note=""
-            if [ -n "$existing_note" ]; then
-              filtered_note=$(printf '%s\n' "$existing_note" | grep -vE '^(status|issue-pr|project):[[:space:]]*' || true)
-            fi
-            new_note=$(
-              { [ -n "$filtered_note" ] && printf '%s\n' "$filtered_note"
-                printf 'status: filed\nissue-pr: %s\nproject: %s\n' "$pr_num" "$project"
-              }
-            )
-            printf '%s' "$new_note" | git notes --ref=pipeline add -f -F - "$sha"
+            # Stage the new-keys-only note content. We do NOT write to the
+            # pipeline ref here: a concurrent writer (bitsweller, bitswelt)
+            # could push between our earlier fetch and our end-of-loop push,
+            # and a non-ff rejection would silently lose status:filed /
+            # issue-pr: / project: for every mirrored commit. Instead, we
+            # buffer (sha, new-keys-content) pairs and apply them with
+            # fetch+re-merge inside a retry loop after the loop completes.
+            staged_shas+=("$sha")
+            staged_contents+=("$(printf 'status: filed\nissue-pr: %s\nproject: %s\n' "$pr_num" "$project")")
 
             created=$((created + 1))
           done <<< "$shas"
 
-          if [ "$DRY_RUN" != "true" ] && [ "$created" -gt 0 ]; then
-            git push origin refs/notes/pipeline 2>/dev/null || true
+          push_notes_with_retry() {
+            local attempts=0
+            while [ "$attempts" -lt 3 ]; do
+              # Re-fetch the latest pipeline notes on each attempt so the
+              # merge sees any keys a concurrent writer just added.
+              git fetch origin '+refs/notes/pipeline:refs/notes/pipeline' 2>/dev/null \
+                || git fetch origin 'refs/notes/pipeline:refs/notes/pipeline' 2>/dev/null \
+                || true
+              local i
+              for i in "${!staged_shas[@]}"; do
+                local sha="${staged_shas[$i]}"
+                local new_content="${staged_contents[$i]}"
+                local existing
+                existing=$(git notes --ref=pipeline show "$sha" 2>/dev/null || true)
+                local filtered=""
+                if [ -n "$existing" ]; then
+                  filtered=$(printf '%s\n' "$existing" | grep -vE '^(status|issue-pr|project):[[:space:]]*' || true)
+                fi
+                local merged
+                merged=$(
+                  { [ -n "$filtered" ] && printf '%s\n' "$filtered"
+                    printf '%s' "$new_content"
+                  }
+                )
+                printf '%s' "$merged" | git notes --ref=pipeline add -f -F - "$sha"
+              done
+              if git push origin refs/notes/pipeline; then
+                return 0
+              fi
+              attempts=$((attempts + 1))
+              echo "notes push failed (attempt $attempts/3), retrying"
+            done
+            echo "::error::notes push failed after 3 attempts; PR(s) created but refs/notes/pipeline not updated"
+            return 1
+          }
+
+          if [ "$DRY_RUN" != "true" ] && [ "${#staged_shas[@]}" -gt 0 ]; then
+            push_notes_with_retry
           fi
 
           echo "created=$created" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Step 4 of the team/project abstraction plan. Adds `.github/workflows/bitsweller-issue-to-pr.yml` — a GitHub Action that mirrors `[BITSWELLER-ISSUE]` commits on the `bitsweller` branch into draft PRs against `main`. Dual-write phase of the "PR-as-issue" migration: bitsweller branch remains authoritative, PR is the portable projection.

**Behavior**:
- Triggers on push to `bitsweller`, or `workflow_dispatch` with `backfill_depth` (default `1`) and `dry_run` (default `false`).
- For each new `[BITSWELLER-ISSUE]` commit: extracts `Project:` trailer (default `bitswell-core`), idempotency-checks via `Source-Issue-Sha:` body sentinel, creates `issue/<shortsha>` branch from `main` with an empty commit, opens draft PR labeled `project:<slug>`, seeds `refs/notes/pipeline` with `status: filed`, `issue-pr: <num>`, `project: <slug>` (merged with existing keys).

## Review history

- **Thorn** (stress-test) blocked the initial version (`7f4df01`) for two silent-failure chains:
  1. `gh pr list` idempotency check swallowed errors → rate-limited rerun could create duplicate PRs.
  2. `refs/notes/pipeline` push swallowed non-ff rejection → status/project never reached remote under contention.
- **Ratchet** addressed both in fixup `7216c84`: `set -e` propagates on the idempotency check; notes writes are staged during the loop and pushed via a 3-attempt retry that re-fetches + re-merges + re-pushes, surfacing `::error::` on final failure.

## Test plan

- [ ] Post-merge: run `gh workflow run "Bitsweller Issue to PR" -f backfill_depth=1 -f dry_run=true` — should list 1 "would create PR" line for `a61ab9f` (newest bitsweller issue, lacks `Project:` trailer → treated as bitswell-core per backward-compat)
- [ ] Then run with `dry_run=false` against the same single commit, verify draft PR created with `project:bitswell-core` label and `refs/notes/pipeline` updated on `a61ab9f`
- [ ] Re-run (any trigger) against `a61ab9f` — idempotency check should skip it cleanly
- [ ] Backfill: `backfill_depth=20` over the full bitsweller history once verified on a single commit

## Process notes

Second Agent Teams dogfood. Shuttle-mode coordinated Ratchet (writer) + Thorn (stress-reviewer). Thorn's adversarial read caught two silent failures that would have been invisible in production until notes desync quietly broke downstream consumers. The review-independence pattern earned its keep again.

— Orchestrated by Shuttle