### PR TITLE
feat(scripts): add project-spawn.sh

### DIFF
--- a/projects/README.md
+++ b/projects/README.md
@@ -12,6 +12,25 @@ Each `projects/<slug>.yaml` has:
 - **`github_project`** — URL of the GitHub Project (board) for this slice, or `null` if not yet created.
 - **`repos`** — list of repo paths (relative to this tree, e.g. `repos/bitswell/loom-tools`) that fall inside the project's scope. May be empty for greenfield projects.
 - **`agents`** — roster of agent slugs authorized to act on this project.
+- **`teams`** *(optional)* — for team-of-teams projects. List of `{ name, agents }` sub-rosters. When present, `agents` remains the project-level roster and `teams` partitions it.
+
+## Spawning a new project
+
+Use `scripts/project-spawn.sh <slug>` to scaffold a new manifest and worktree root in one step. The script writes `projects/<slug>.yaml` and creates `.loom/projects/<slug>/.gitkeep` so Shuttle can dispatch into it.
+
+```sh
+# Minimal:
+scripts/project-spawn.sh kiln --description "Long-running batch training."
+
+# With submodules, GitHub Project, team-of-teams, or actor reuse:
+scripts/project-spawn.sh forge \
+  --repo repos/bitswell/loom-tools \
+  --github-project https://github.com/orgs/bitswell/projects/3 \
+  --teams "runtime,workers" \
+  --actors-from .
+```
+
+`--dry-run` prints the manifest without touching the tree. `--help` lists every flag. `--actors-from <path>` symlinks that path's `.claude/agents/` into the spawned project's worktree root — the seam a future actors submodule slots into without reworking the tool.
 
 ## Current projects
 

--- a/scripts/project-spawn.sh
+++ b/scripts/project-spawn.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+# project-spawn.sh — Scaffold a new bitswell project.
+#
+# Creates:
+#   - projects/<slug>.yaml              (the manifest, committed)
+#   - .loom/projects/<slug>/.gitkeep    (worktree root, so Shuttle can dispatch)
+#
+# Optionally links agent definitions from an actors source (another repo,
+# a submodule, or the current tree's .claude/agents/) so the project's
+# worktrees resolve the same roster that its manifest declares. The link
+# is only created if --actors-from is passed explicitly — by default the
+# tree is left alone and Claude Code inherits .claude/agents/ from the
+# primary worktree as usual.
+#
+# Usage:
+#   scripts/project-spawn.sh <slug> [options]
+#
+# Required:
+#   <slug>                         Short kebab-case identifier. Becomes
+#                                  projects/<slug>.yaml and the worktree
+#                                  prefix .loom/projects/<slug>/.
+#
+# Options:
+#   --name <display-name>          Human-readable name. Defaults to slug
+#                                  title-cased.
+#   --description <prose>          Free-form description written into the
+#                                  manifest. Defaults to a stub the author
+#                                  is expected to edit.
+#   --repo <path>                  Repo path (relative to the tree root,
+#                                  e.g. repos/bitswell/loom-tools). Repeat
+#                                  for multiple. Defaults to none
+#                                  (greenfield project).
+#   --agents <csv>                 Comma-separated agent slugs authorized
+#                                  on this project. Defaults to the full
+#                                  standard roster (matches bitswell-core).
+#   --actors-from <path>           Path to a tree whose .claude/agents/
+#                                  directory should be symlinked into the
+#                                  spawned project's worktree root. Use to
+#                                  point at a future actors submodule.
+#                                  If omitted, no link is created.
+#   --github-project <url>         Project (board) URL to record. Null by
+#                                  default; fill in after creating the
+#                                  board.
+#   --teams <csv>                  Comma-separated team names for
+#                                  team-of-teams projects. When provided,
+#                                  the manifest gains a `teams:` list
+#                                  alongside `agents:`. Each team is
+#                                  recorded with an empty agent sub-roster
+#                                  for the author to fill in.
+#   --force                        Overwrite an existing manifest.
+#   --dry-run                      Print what would happen; touch nothing.
+#   -h | --help                    This message.
+#
+# Examples:
+#   # Minimal greenfield:
+#   scripts/project-spawn.sh kiln --name Kiln \
+#     --description "Long-running batch training project."
+#
+#   # With existing submodules + a GitHub Project:
+#   scripts/project-spawn.sh forge --name Forge \
+#     --repo repos/bitswell/loom-tools \
+#     --repo repos/bitswell/memctl \
+#     --github-project https://github.com/orgs/bitswell/projects/3
+#
+#   # Team-of-teams scaffold:
+#   scripts/project-spawn.sh atlas --name Atlas \
+#     --teams "runtime,workers,observability"
+#
+# After spawn, the author is expected to:
+#   1. Edit the generated manifest (description, agents roster if non-default).
+#   2. Commit the manifest + .loom/projects/<slug>/.gitkeep on a PR branch.
+#   3. (Later) Create the GitHub Project board and fill in github_project.
+
+set -euo pipefail
+
+DEFAULT_AGENTS="bitswell,shuttle,bitsweller,vesper,ratchet,moss,drift,sable,thorn,glitch,bitswelt"
+
+die() {
+  echo "project-spawn: $*" >&2
+  exit 1
+}
+
+usage() {
+  sed -n '/^# project-spawn.sh/,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+  exit "${1:-0}"
+}
+
+slug=""
+name=""
+description=""
+repos=()
+agents_csv=""
+actors_from=""
+github_project=""
+teams_csv=""
+force=0
+dry_run=0
+
+while (( $# > 0 )); do
+  case "$1" in
+    -h|--help)        usage 0 ;;
+    --name)           name="${2:?--name requires an argument}"; shift 2 ;;
+    --description)    description="${2:?--description requires an argument}"; shift 2 ;;
+    --repo)           repos+=("${2:?--repo requires an argument}"); shift 2 ;;
+    --agents)         agents_csv="${2:?--agents requires an argument}"; shift 2 ;;
+    --actors-from)    actors_from="${2:?--actors-from requires an argument}"; shift 2 ;;
+    --github-project) github_project="${2:?--github-project requires an argument}"; shift 2 ;;
+    --teams)          teams_csv="${2:?--teams requires an argument}"; shift 2 ;;
+    --force)          force=1; shift ;;
+    --dry-run)        dry_run=1; shift ;;
+    --)               shift; break ;;
+    -*)               die "unknown flag: $1 (try --help)" ;;
+    *)
+      if [[ -z "$slug" ]]; then
+        slug="$1"
+        shift
+      else
+        die "unexpected positional argument: $1"
+      fi
+      ;;
+  esac
+done
+
+[[ -n "$slug" ]] || die "missing <slug>. Run with --help."
+
+# slug must be kebab-case: lowercase letters, digits, single dashes.
+if ! [[ "$slug" =~ ^[a-z][a-z0-9]*(-[a-z0-9]+)*$ ]]; then
+  die "slug '$slug' is not valid kebab-case (lowercase letters/digits, single dashes, starting with a letter)."
+fi
+
+repo_top=$(git rev-parse --show-toplevel 2>/dev/null) \
+  || die "not inside a git worktree."
+cd "$repo_top"
+
+manifest_path="projects/${slug}.yaml"
+worktree_dir=".loom/projects/${slug}"
+gitkeep_path="${worktree_dir}/.gitkeep"
+
+if [[ -e "$manifest_path" && $force -eq 0 ]]; then
+  die "manifest $manifest_path already exists. Use --force to overwrite."
+fi
+
+if [[ -n "$actors_from" ]]; then
+  # Resolve relative to repo root for a stable symlink target.
+  if [[ ! -d "$actors_from/.claude/agents" ]]; then
+    die "--actors-from '$actors_from' has no .claude/agents/ directory."
+  fi
+fi
+
+# Derive defaults.
+if [[ -z "$name" ]]; then
+  # Title-case the slug: "foo-bar-baz" -> "Foo Bar Baz".
+  name=$(echo "$slug" | awk 'BEGIN{RS="-"; ORS=" "} {print toupper(substr($0,1,1)) substr($0,2)}' | sed 's/ $//')
+fi
+
+if [[ -z "$description" ]]; then
+  description="TODO: describe this project."
+fi
+
+agents_csv="${agents_csv:-$DEFAULT_AGENTS}"
+
+# Split CSVs into bash arrays (IFS-safe, trims surrounding spaces).
+IFS=',' read -r -a agents_list <<<"$agents_csv"
+teams_list=()
+if [[ -n "$teams_csv" ]]; then
+  IFS=',' read -r -a teams_list <<<"$teams_csv"
+fi
+
+format_description() {
+  local prose="$1"
+  # YAML block-literal with two-space indent. Preserves newlines, keeps the
+  # author's wording intact.
+  echo "  $prose" | sed 's/$//'
+}
+
+render_manifest() {
+  {
+    echo "slug: ${slug}"
+    echo "name: ${name}"
+    echo "description: |"
+    echo "  ${description}"
+    if [[ -n "$github_project" ]]; then
+      echo "github_project: ${github_project}"
+    else
+      echo "github_project: null  # TODO: link when a board is created"
+    fi
+    if (( ${#repos[@]} == 0 )); then
+      echo "repos: []  # Greenfield — add submodule paths as the project develops"
+    else
+      echo "repos:"
+      for r in "${repos[@]}"; do
+        echo "  - ${r}"
+      done
+    fi
+    echo "agents:"
+    for a in "${agents_list[@]}"; do
+      a_trimmed="${a## }"; a_trimmed="${a_trimmed%% }"
+      [[ -n "$a_trimmed" ]] && echo "  - ${a_trimmed}"
+    done
+    if (( ${#teams_list[@]} > 0 )); then
+      echo "teams:"
+      for t in "${teams_list[@]}"; do
+        t_trimmed="${t## }"; t_trimmed="${t_trimmed%% }"
+        [[ -z "$t_trimmed" ]] && continue
+        echo "  - name: ${t_trimmed}"
+        echo "    agents: []  # TODO: roster for team '${t_trimmed}'"
+      done
+    fi
+  }
+}
+
+if (( dry_run )); then
+  echo "[dry-run] would write ${manifest_path}:"
+  echo "---8<---"
+  render_manifest
+  echo "--->8---"
+  echo "[dry-run] would create ${gitkeep_path}"
+  if [[ -n "$actors_from" ]]; then
+    echo "[dry-run] would symlink ${worktree_dir}/.claude/agents -> ${actors_from}/.claude/agents"
+  fi
+  exit 0
+fi
+
+mkdir -p "$(dirname "$manifest_path")"
+mkdir -p "$worktree_dir"
+
+render_manifest >"$manifest_path"
+
+if [[ ! -e "$gitkeep_path" ]]; then
+  touch "$gitkeep_path"
+fi
+
+if [[ -n "$actors_from" ]]; then
+  link_target="${worktree_dir}/.claude/agents"
+  mkdir -p "$(dirname "$link_target")"
+  if [[ -L "$link_target" || -e "$link_target" ]]; then
+    rm -rf "$link_target"
+  fi
+  # Use a path relative to the link's directory for portability.
+  rel=$(python3 -c "import os,sys; print(os.path.relpath(sys.argv[1], sys.argv[2]))" \
+    "${repo_top}/${actors_from}/.claude/agents" "${repo_top}/$(dirname "$link_target")")
+  ln -s "$rel" "$link_target"
+fi
+
+cat <<EOF
+project-spawn: created '${slug}'
+  manifest:  ${manifest_path}
+  worktree:  ${worktree_dir}/
+EOF
+
+if [[ -n "$actors_from" ]]; then
+  echo "  actors:    ${worktree_dir}/.claude/agents -> ${actors_from}/.claude/agents (symlink)"
+fi
+
+cat <<'EOF'
+
+Next steps:
+  1. Review and edit the manifest (description, roster, repos).
+  2. Create a worktree under .loom/projects/<slug>/<role>/<slug> from main.
+  3. Commit the manifest on a PR branch; open a PR against main.
+  4. Create the GitHub Project board and fill in github_project.
+EOF


### PR DESCRIPTION
## Summary

One bash entry-point — `scripts/project-spawn.sh <slug>` — that scaffolds a new project: writes `projects/<slug>.yaml`, creates `.loom/projects/<slug>/.gitkeep`, and (optionally) symlinks `.claude/agents/` from an actors source so a future actors submodule slots in without reworking the tool.

Answers the user's prompt *\"create a tool which spawns a new project, allowing a team or team-of-teams, with actors generated or reused from other branches\"* in the minimum shape that lands today: the tool exists, is documented, supports reuse of an existing actor set via `--actors-from`, and models team-of-teams via `--teams` producing a `teams:` block in the manifest. Actor *generation* and a shared actors repo / memory-consolidation model are deliberately out of scope for this PR and tracked for a follow-up.

## What's in this PR

- `scripts/project-spawn.sh` — the tool. Flags: `--name`, `--description`, `--repo` (repeatable), `--agents` (CSV), `--actors-from <path>`, `--github-project`, `--teams` (CSV), `--force`, `--dry-run`, `--help`. Validates slug as kebab-case; refuses to overwrite without `--force`.
- `projects/README.md` — documents usage + adds `teams` to the schema.

## Verified locally

- `--help` prints the header block.
- Dry-run for `forge` (with two repos + board URL) renders the expected YAML.
- Dry-run for `atlas --teams "runtime,workers,observability" --agents "bitswell,shuttle"` produces a `teams:` block.
- Slug validation rejects `bad_slug` and `_smoketest`.
- Existing-manifest guard rejects `bitswell-core` without `--force`.
- Missing `--actors-from` target rejected.
- Real spawn of a throwaway `smoketest` project wrote manifest + `.gitkeep` + symlink; symlink resolved to the 11 agent defs; `--force` re-rendered in place; cleanup removed artifacts cleanly.

## Test plan

- [ ] `./scripts/project-spawn.sh --help` prints usage.
- [ ] `./scripts/project-spawn.sh kiln --description 'test' --dry-run` prints a well-formed manifest.
- [ ] Real spawn on a throwaway slug, then remove `projects/<slug>.yaml` and `.loom/projects/<slug>/`.

## Follow-ups (not this PR)

- Shared `actors/` submodule extracting `.claude/agents/` + `agents/<name>/identity.md` + per-agent memory, so `--actors-from repos/bitswell/actors` consolidates memory across projects.
- Generated actors — personality + identity templates rendered from a spec (LLM or YAML-driven).
- Auto-create the GitHub Project board when `--github-project` is omitted.

Agent-Id: bitswell
Session-Id: bitswell-core-project-spawn-tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)