### PR TITLE
fix(pipeline-notes): key-replace semantics via scripts/pipeline-note-set.sh

### DIFF
--- a/.claude/agents/bitswelt.md
+++ b/.claude/agents/bitswelt.md
@@ -56,18 +56,19 @@ You are Bitswelt — the approval gate. A fork of Bitsweller with the same optim
 
 6. **If Blocked/Needs Revision**: Post `gh pr review --request-changes` with clear instructions on what needs to change. Specify whether it goes back to a writer or a reviewer. The task branch stays; the writer pushes new commits to the loom branch.
 
-7. **Pipeline Note** (on approval): Write a `refs/notes/pipeline` note on the originating bitsweller issue commit. Approval is not complete until this note exists.
+7. **Pipeline Note** (on approval): Update the `refs/notes/pipeline` note on the originating bitsweller issue commit. Approval is not complete until this note exists. Use `scripts/pipeline-note-set.sh`, which replaces existing values for the given keys rather than appending — earlier keys (e.g. `issue-pr` seeded by the GHA, `task-branch`/`planned-*` written by vesper) survive untouched:
    ```
-   git notes --ref=pipeline add <issue-sha> -m "$(cat <<'NOTEEOF'
-   status: shipped
-   impl-repo: <org>/<repo>
-   impl-pr: <number>
-   impl-merged-sha: <sha>
-   impl-merged-at: <ISO timestamp>
-   reviewers: [<agents>]
-   retro: <retro-sha>       # filled after step 8
-   NOTEEOF
-   )"
+   ./scripts/pipeline-note-set.sh <issue-sha> \
+     status=shipped \
+     impl-repo=<org>/<repo> \
+     impl-pr=<number> \
+     impl-merged-sha=<sha> \
+     impl-merged-at=<ISO timestamp> \
+     reviewers=[<agents>] \
+     approved-by=bitswelt \
+     approved-at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+   # `retro=<sha>` is filled by the same helper after step 8.
+   git push origin refs/notes/pipeline
    ```
    Status values: `filed | planned | assigned | in-review | shipped | abandoned`. You write the `shipped` transition.
 
@@ -90,7 +91,7 @@ You are Bitswelt — the approval gate. A fork of Bitsweller with the same optim
    Agent-Id: bitswelt
    Session-Id: <session-uuid>
    ```
-   "Signal for future planning" is load-bearing — it's the sentence vesper reads before decomposing the next similar issue. Everything else is context. After the retro commit, update the pipeline note to include `retro: <sha>`. Push both `retros` and `refs/notes/pipeline`.
+   "Signal for future planning" is load-bearing — it's the sentence vesper reads before decomposing the next similar issue. Everything else is context. After the retro commit, update the pipeline note with `./scripts/pipeline-note-set.sh <issue-sha> retro=<sha>`. Push both `retros` and `refs/notes/pipeline`.
 
 **Approval Principles**:
 - Same optimization obsession as Bitsweller — memory usage is your primary lens

--- a/.claude/agents/vesper.md
+++ b/.claude/agents/vesper.md
@@ -68,10 +68,14 @@ You are Vesper — The Philosopher. You treat every design choice as philosophy 
    ```
    The blank line before `Project:` is load-bearing — a stray non-`Key: value` line anywhere in the trailer block silently voids the entire block (see MEMORY `feedback_git_trailer_format.md`).
 
-5. **Mark the Source Issue as Planned**: Append a pipeline note on the bitsweller commit so readers of `git log bitsweller --show-notes=pipeline` see the link:
+5. **Mark the Source Issue as Planned**: Update the pipeline note on the bitsweller commit so readers of `git log bitsweller --show-notes=pipeline` see the link. Use `scripts/pipeline-note-set.sh`, which replaces existing values for the given keys rather than appending — other keys (e.g. `issue-pr` seeded by the GHA, `impl-pr`/`retro` written by bitswelt later) survive untouched:
    ```
-   git notes --ref=pipeline append <bitsweller-sha> -m "status: planned
-   task-branch: task/<project-slug>/<task-slug>"
+   ./scripts/pipeline-note-set.sh <bitsweller-sha> \
+     status=planned \
+     task-branch=task/<project-slug>/<task-slug> \
+     planned-by=vesper \
+     planned-at=$(date +%Y-%m-%d) \
+     planned-session=<your-session-id>
    git push origin refs/notes/pipeline
    ```
 

--- a/.github/workflows/bitsweller-issue-to-pr.yml
+++ b/.github/workflows/bitsweller-issue-to-pr.yml
@@ -189,6 +189,9 @@ jobs:
                 || git fetch origin 'refs/notes/pipeline:refs/notes/pipeline' 2>/dev/null \
                 || true
               local i
+              # Key-replace semantics, inlined here so the runner doesn't need
+              # scripts/pipeline-note-set.sh on PATH. Local callers use that
+              # script instead of duplicating this block.
               for i in "${!staged_shas[@]}"; do
                 local sha="${staged_shas[$i]}"
                 local new_content="${staged_contents[$i]}"

--- a/scripts/pipeline-note-set.sh
+++ b/scripts/pipeline-note-set.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# pipeline-note-set.sh — set key:value lines on refs/notes/pipeline,
+# replacing any existing lines for the same keys while preserving the rest.
+#
+# Usage:
+#   scripts/pipeline-note-set.sh <commit-sha> key=value [key=value ...]
+#
+# Semantics:
+#   1. Read the existing refs/notes/pipeline note on <commit-sha> (if any).
+#   2. Drop every line matching ^(key1|key2|...):[[:space:]]* for the keys
+#      being set.
+#   3. Append the new `key: value` lines in the argument order given.
+#   4. Force-overwrite the note via `git notes --ref=pipeline add -f -F -`.
+#
+# Does not push refs/notes/pipeline; the caller decides when to push.
+# Must be run from inside the repo working tree so `git notes` finds the ref.
+#
+# Exit codes:
+#   0 — success
+#   1 — bad usage (missing sha, missing kv args, malformed key=value)
+
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "usage: $0 <commit-sha> key=value [key=value ...]" >&2
+  exit 1
+fi
+
+sha="$1"
+shift
+
+keys=()
+pairs=()
+for arg in "$@"; do
+  if [[ "$arg" != *=* ]]; then
+    echo "error: malformed argument '$arg' (expected key=value)" >&2
+    exit 1
+  fi
+  key="${arg%%=*}"
+  value="${arg#*=}"
+  if [[ -z "$key" ]]; then
+    echo "error: empty key in '$arg'" >&2
+    exit 1
+  fi
+  keys+=("$key")
+  pairs+=("$key" "$value")
+done
+
+existing=$(git notes --ref=pipeline show "$sha" 2>/dev/null || true)
+
+filter_re=""
+for k in "${keys[@]}"; do
+  esc=$(printf '%s' "$k" | sed 's/[][\\.^$*+?(){}|/]/\\&/g')
+  if [[ -z "$filter_re" ]]; then
+    filter_re="$esc"
+  else
+    filter_re="$filter_re|$esc"
+  fi
+done
+
+filtered=""
+if [[ -n "$existing" ]]; then
+  filtered=$(printf '%s\n' "$existing" | grep -vE "^(${filter_re}):[[:space:]]*" || true)
+fi
+
+{
+  if [[ -n "$filtered" ]]; then
+    printf '%s\n' "$filtered"
+  fi
+  i=0
+  while [[ $i -lt ${#pairs[@]} ]]; do
+    printf '%s: %s\n' "${pairs[$i]}" "${pairs[$((i+1))]}"
+    i=$((i+2))
+  done
+} | git notes --ref=pipeline add -f -F - "$sha"


### PR DESCRIPTION
## Summary

Step 5 follow-up, caught during the end-to-end dogfood: `refs/notes/pipeline` was accreting. When Vesper wrote `status: planned` and Bitswelt wrote `status: shipped`, both used `git notes --ref=pipeline append`, so a single commit ended up with two `status:` entries and downstream consumers had to rely on "last occurrence wins".

Fix: `scripts/pipeline-note-set.sh <sha> key=value [key=value ...]` — reads the existing note, drops lines for any key being set, appends the new `key: value` lines, writes with `git notes add -f -F -`. Does not push (caller decides). Vesper's step 5 and Bitswelt's approval flow now call it.

## Verified locally

Smoke test in the worktree against HEAD:

```
Before:
status: filed
issue-pr: 999
extra-key: preserved

./scripts/pipeline-note-set.sh <sha> status=shipped impl-pr=92 retro=abc123

After:
issue-pr: 999
extra-key: preserved
status: shipped
impl-pr: 92
retro: abc123
```

Keys in the set list get replaced; others are preserved; new keys appended. Multi-line values with spaces handled via `printf '%s: %s\n'`.

## Files changed

- `scripts/pipeline-note-set.sh` (new, executable)
- `.claude/agents/vesper.md` — step 5 uses the helper
- `.claude/agents/bitswelt.md` — steps 7 & 8 (approval note + retro-link) use the helper
- `.github/workflows/bitsweller-issue-to-pr.yml` — three-line pointer comment near the inline merge block noting the script is the local equivalent (the GHA stays inline — runtime doesn't need the script on PATH)

## Not in scope

`.claude/agents/bitsweller.md:47` still writes `status: filed` via `git notes add` directly and not through the helper. Moss flagged this: bitsweller's `status: filed` is also redundant with the Step 4 GHA (which seeds `filed` on mirror), so there's a separate question of whether bitsweller should write it at all. Worth a follow-up bitsweller issue.

— Orchestrated by Shuttle