### PR TITLE
fix(bitsweller): retire direct refs/notes/pipeline seed; GHA is authoritative

### DIFF
--- a/.claude/agents/bitsweller.md
+++ b/.claude/agents/bitsweller.md
@@ -42,11 +42,7 @@ You are Bitsweller — the self-improvement arm of Bitswell. You are an elite op
 
 4. **Branch Management**: You operate on your own dedicated branch. Always ensure you are working on the bitsweller branch. If it doesn't exist, create it. Never commit directly to main or other development branches. Never use the git commit command for anything other than filing your improvement issues.
 
-5. **Pipeline Note**: After filing each issue commit, write a `refs/notes/pipeline` note on it with `status: filed`:
-   ```
-   git notes --ref=pipeline add <sha> -m "status: filed"
-   ```
-   Push with `git push origin refs/notes/pipeline`. This seeds the pipeline tracking that bitswelt completes at approval time.
+5. **Pipeline Note** (handled automatically): After you push the `bitsweller` branch, the `bitsweller-issue-to-pr` GitHub Action (`.github/workflows/bitsweller-issue-to-pr.yml`) mirrors each `[BITSWELLER-ISSUE]` commit as a draft PR against `main` and seeds `refs/notes/pipeline` on your commit with `status: filed`, `issue-pr: <n>`, and `project: <slug>`. You do **not** write the note yourself — let the GHA be the single writer of the initial filed state. Downstream writers (vesper, bitswelt) use `scripts/pipeline-note-set.sh` which preserves the GHA-written keys and adds its own.
 
 **Important Git Workflow**:
 - Never commit to main or other branches

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ Project identity and values are in `AGENT.md`. Agent identities are in `agents/<
 
 Three git-native mechanisms track work from issue through merge:
 
-- **`refs/notes/pipeline`** — YAML notes attached to bitsweller issue commits. Track status (`filed → planned → assigned → in-review → shipped → abandoned`), implementation PR, reviewers, and retro link. Written by bitsweller (filed), vesper (planned), bitswell (assigned), bitswelt (shipped). Fetch with `git fetch origin refs/notes/pipeline:refs/notes/pipeline`, view with `git log bitsweller --show-notes=pipeline`.
+- **`refs/notes/pipeline`** — YAML notes attached to bitsweller issue commits. Track status (`filed → planned → assigned → in-review → shipped → abandoned`), implementation PR, reviewers, and retro link. Written by the `bitsweller-issue-to-pr` GHA (filed), vesper (planned), bitswell (assigned), bitswelt (shipped), all via `scripts/pipeline-note-set.sh` which preserves existing keys and replaces only the ones being set. Fetch with `git fetch origin refs/notes/pipeline:refs/notes/pipeline`, view with `git log bitsweller --show-notes=pipeline`.
 - **`retros` branch** — Orphan branch, one commit per merged PR. 5-heading template (What worked / What surprised us / What we'd do differently / Follow-ups filed / Signal for future planning). Written by bitswelt at approval time. Ceiling: 15 lines.
 - **`Bitsweller-Issue: <sha>` trailer** — Added to merge commits in implementation repos (loom-tools, memctl, etc.) to close the reverse link from PR back to issue. Makes the backlink grep-exact.
 


### PR DESCRIPTION
## Summary

Closes the inconsistency flagged during PR #94 review: bitsweller.md step 5 wrote `status: filed` directly to `refs/notes/pipeline`, which both duplicated what the Step 4 GHA seeds on mirror and bypassed the new `scripts/pipeline-note-set.sh` key-replace semantics.

**Change**: bitsweller's step 5 now says "handled automatically" and points at the GHA. CLAUDE.md's pipeline-visibility bullet updated to name the GHA as the `filed` writer and the helper script as the common writer for later transitions.

## Net effect

- Single writer of `status: filed` → the GHA (triggers on push to `bitsweller` branch).
- Vesper / Bitswelt / (future) Bitswell-on-assign all go through `scripts/pipeline-note-set.sh` which preserves existing keys.
- No more local-vs-remote drift risk on the initial filed state.

— Orchestrated by Shuttle