### PR TITLE
feat(ember): plant architecture spec (Hetzner pilot + RunPod + Tailscale)

### DIFF
--- a/docs/ember/architecture.md
+++ b/docs/ember/architecture.md
@@ -1,0 +1,43 @@
+# Ember Architecture
+
+Ember is a pilot-light GPU orchestrator: one always-on Hetzner VPS summons ephemeral RunPod GPU workers on demand and joins them to a Tailscale mesh. The pilot is cheap and idle most of the time; the workers are expensive and short-lived. This document pins the five decisions every downstream issue will read against.
+
+## Hetzner VPS size
+
+**Recommendation:** CX22 (2 vCPU / 4 GB / €3.79).
+
+The pilot runs SSH, a small HTTP control API, and a Tailscale client — none of which stress 2 vCPU / 4 GB. CX32 becomes justified only if the pilot ever starts holding worker state (queues, artifact cache); flag that as the flip point.
+
+## RunPod GPU dispatch
+
+**Recommendation:** On-demand pods triggered by a direct GraphQL call from the pilot, with a per-pod 2-hour runtime cap and a €20/day spend ceiling enforced pilot-side before the API call.
+
+Spot is cheaper but eviction mid-job is a pilot-light footgun; on-demand keeps the trigger path synchronous and the failure modes few. Guardrails live on the pilot rather than in RunPod because that is the only place we fully trust.
+
+## Tailscale topology
+
+**Recommendation:** Direct peer mode — pilot and workers are individual tailnet nodes, no subnet router. Tag workers `tag:ember-worker` and the pilot `tag:ember-pilot`; ACL permits `tag:ember-pilot → tag:ember-worker:22` only.
+
+Subnet routing earns its weight when bridging a LAN; for point-to-point SSH between two Tailscale nodes it is pure overhead. ACL-by-tag scopes blast radius if a worker's key ever leaks.
+
+## Control-plane surface
+
+**Recommendation:** A single CLI binary on the pilot — `ember summon --gpu 4090 --image …` — that blocks until the worker is reachable and prints its MagicDNS name (e.g. `ember-worker-abc.tail-scale.ts.net`) on stdout.
+
+A CLI is the smallest surface that still composes in shell pipelines; HTTP and event-driven designs become warranted once there is more than one caller or the summon is cross-host. MagicDNS avoids baking IPs into callers.
+
+## Secrets + auth
+
+**Recommendation:** sops-encrypted secrets file in the pilot's repo, decrypted at boot with an age key stored on the pilot's root-owned disk; RunPod API key, Tailscale auth key, and Hetzner token all live in that file. Rotate the RunPod and Tailscale keys quarterly, Hetzner token on personnel change.
+
+sops+age is the lightest tool that survives audit — plain env vars lose the rotation story, and Vault is infrastructure the pilot cannot justify. If the pilot ever grows from one operator to a team, revisit: OIDC-fronted Tailscale + short-lived RunPod tokens becomes the better shape.
+
+## Future work
+
+- ember-orchestrator repo bootstrap (pilot codebase — CLI, HTTP shim if needed, provisioning script).
+- sops/age workflow: key generation, commit encrypted file, pilot boot-time decrypt hook.
+- Hetzner provisioning script (Terraform or cloud-init) with CI that validates it applies cleanly.
+- RunPod GraphQL client module with the per-pod runtime cap and daily spend ceiling baked in.
+- Tailscale ACL definition committed alongside the orchestrator, applied via `tailscale set --advertise-tags`.
+
+— Built by Moss


### PR DESCRIPTION
## Summary

First content PR for the Ember project. Adds `docs/ember/architecture.md` — a 43-line spec covering five decision points the Tier-2 stack needs pinned before implementation can start.

Recommendations (one line each):

1. **Hetzner VPS** — CX22 (2 vCPU / 4 GB / €3.79). Flip to CX32 if the pilot grows to hold state.
2. **RunPod dispatch** — On-demand direct GraphQL; per-pod 2h cap, €20/day ceiling enforced pilot-side. Spot is a pilot-light footgun.
3. **Tailscale** — Direct peer, no subnet router. Tags `ember-pilot`/`ember-worker`, ACL `pilot → worker:22` only.
4. **Control plane** — Single CLI on the pilot (`ember summon …`), blocks until worker reachable, prints MagicDNS name.
5. **Secrets** — sops-encrypted with age key on pilot root disk; quarterly rotation for RunPod/Tailscale.

Two flip-later decisions flagged in the spec (Hetzner size, secrets model).

## Source chain (dogfood run)

- Bitsweller issue: `972ea4f` ("[BITSWELLER-ISSUE] ember: plant initial architecture spec") — first `Project: ember` issue filed.
- Mirrored issue PR: #96 (Step 4 GHA, triggered via workflow_dispatch since the GHA file lives on main, not on the bitsweller branch — see known-bug note below).
- Task branch: `task/ember/architecture-spec` @ `9d90d67` (Vesper-planned). Task body preserved as earliest commit of this PR.
- Pipeline note on `972ea4f`: `filed → planned` via `scripts/pipeline-note-set.sh`. GHA-written `issue-pr: 96` and `project: ember` keys preserved.

## What this run validated

- **Multi-project `Project:` trailer filter works**: Vesper's `awk '$2=="ember"'` returned exactly 1 line (the ember issue) out of 124 bitsweller commits. The Step 3 filter is grep-exact.
- **`scripts/pipeline-note-set.sh` on a real mixed note**: the helper correctly replaced `status` while preserving `issue-pr`, `project`, and adding `task-branch`, `planned-by`, `planned-at`, `planned-session`. No duplicate status lines (the bug the script was written to fix).
- **Task-branch protocol**: writer worktree branched off the task branch; task body is this PR's earliest commit.

## Known bugs surfaced this run (not in this PR's scope)

1. **GHA doesn't trigger on push to `bitsweller`** because the workflow file (`.github/workflows/bitsweller-issue-to-pr.yml`) lives on `main`, not on `bitsweller`. GitHub Actions resolves push-triggered workflows from the pushed branch. Worked around with `workflow_dispatch` this run; needs a structural fix (merge main into bitsweller, or move trigger to `workflow_run` on a cross-branch event).
2. **GHA notes-push retry reports failure but notes land**: the retry loop emitted `::error::notes push failed after 3 attempts` yet the note is on origin after a forced fetch. Either the retry semantics are wrong or the error is spurious. Minor.

Both findings are added to the plan's follow-up list.

— Orchestrated by Shuttle