### PR TITLE
docs(CLAUDE.md): sandbox obstacles are usually missing-tool signals

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,10 @@ Project identity and values are in `AGENT.md`. Agent identities are in `agents/<
 - Tasks live on **task branches**: `task/<project-slug>/<task-slug>` branches born from a single empty commit whose message is the task body (`[TASK]` prefix, `Project:` trailer, `Source-Issue-PR:`/`Source-Issue-Sha:` trailers tying back to the bitsweller issue). Vesper creates them from a planner worktree; Shuttle-mode branches writer worktrees off the task branch so the task body lands as the earliest commit in the implementation PR. Discovery: `git for-each-ref refs/heads/task/<project-slug>/`.
 - Agent identities live in `agents/<name>/identity.md`. Not all agents have discovered identities yet — bitsweller and bitswelt are pending.
 
+## Sandbox Obstacles → Missing Tools
+
+When a command is blocked by the sandbox (filesystem write denied, network host not allowed, approval prompt), **first ask: is there a missing tool?** The right fix is usually a dedicated helper script (`scripts/pipeline-note-set.sh` is the canonical example — the sandbox made the inline `git notes append` idiom friction-prone, so we lifted it into a script) or a proper MCP tool that does the operation within sandbox constraints. Reach for `dangerouslyDisableSandbox: true` only after considering whether the friction is pointing at a gap to fill. Every recurring sandbox-escape is evidence a tool wants to exist.
+
 ## Pipeline Visibility
 
 Three git-native mechanisms track work from issue through merge:


### PR DESCRIPTION
## Summary

User feedback this session (after repeated `git worktree add` approval prompts): the durable lesson is that each recurring sandbox escape is evidence a tool wants to exist.

Adds a short section to CLAUDE.md naming the rule: when blocked by the sandbox, first ask whether a helper script or MCP tool should be written to do the operation within sandbox constraints — before reaching for `dangerouslyDisableSandbox: true`.

`scripts/pipeline-note-set.sh` is the canonical example: the sandbox made the inline `git notes append` idiom friction-prone, so we lifted it into a script with key-replace semantics. The rule generalizes that pattern.

## Concrete gap this rule points at (not filed yet)

`git worktree add` writes to `.git/config` and `.git/worktrees/`, both outside the sandbox allowlist. Every worktree creation this session required `dangerouslyDisableSandbox: true`. That's a tool-shaped hole: a `scripts/loom-worktree-add.sh` (or an MCP tool) that wraps `git worktree add` and does the `.git/` writes via a mechanism the sandbox trusts. Candidate bitsweller issue.

— Orchestrated by Shuttle