### PR TITLE
chore(gitignore): ignore Claude runtime lock files at repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ node_modules/
 /.claude/commands
 /.claude/skills
 /.claude/agent-memory/
+/.claude/*.lock
 /.mcp.json
 /.playwright-mcp/
 


### PR DESCRIPTION
## Summary

`/.claude/scheduled_tasks.lock` is runtime state written by Claude Code's scheduler during active sessions. It was appearing in every `git status` at the primary worktree throughout this session. One-line gitignore addition to the existing Claude-runtime block, using `/.claude/*.lock` so any future lock-file variants are covered.

— Orchestrated by Shuttle