### PR TITLE
chore(gitignore): match .vscode/.idea as files too (sandbox char-devices)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,11 +3,12 @@
 Thumbs.db
 
 # Editor
+# (Patterns without trailing slash so they match sandbox char-device bind-mounts as well as real dirs)
 *.swp
 *.swo
 *~
-.vscode/
-.idea/
+.vscode
+.idea
 
 # Node (if ever needed)
 node_modules/


### PR DESCRIPTION
## Summary

- `.vscode/` and `.idea/` in .gitignore use trailing slashes (directory-only match).
- Sandbox mounts `/dev/null` over those paths at the top of the primary worktree so IDE state doesn't leak in. Those become **character devices**, not directories, so the patterns miss them and status shows them as untracked on every session.
- Drop the trailing slash so patterns match either shape.

## Test plan
- [ ] Merge, then `git status` at primary worktree no longer reports `.vscode` or `.idea` as untracked.